### PR TITLE
Quick bugfix

### DIFF
--- a/cassiopeia/preprocess/utilities.py
+++ b/cassiopeia/preprocess/utilities.py
@@ -355,10 +355,10 @@ def convert_alleletable_to_character_matrix(
     alleletable: pd.DataFrame,
     ignore_intbcs: List[str] = [],
     allele_rep_thresh: float = 1.0,
-    missing_data_state: str = "-",
+    missing_data_state: int = -1,
     mutation_priors: Optional[pd.DataFrame] = None,
 ) -> Tuple[
-    pd.DataFrame, Dict[int, Dict[str, float]], Dict[int, Dict[str, str]]
+    pd.DataFrame, Dict[int, Dict[int, float]], Dict[int, Dict[int, str]]
 ]:
     """Converts an alleletable into a character matrix.
 
@@ -451,28 +451,28 @@ def convert_alleletable_to_character_matrix(
                     continue
 
                 if state == "NONE" or "None" in state:
-                    character_strings[sample].append("0")
+                    character_strings[sample].append(0)
                 else:
                     if state in allele_counter[c]:
                         character_strings[sample].append(
-                            str(allele_counter[c][state])
+                            allele_counter[c][state]
                         )
                     else:
                         # if this is the first time we're seeing the state for this character,
                         # add a new entry to the allele_counter
                         allele_counter[c][state] = len(allele_counter[c]) + 1
                         character_strings[sample].append(
-                            str(allele_counter[c][state])
+                            allele_counter[c][state]
                         )
 
                         # add a new entry to the character's probability map
                         if mutation_priors is not None:
                             prob = np.mean(mutation_priors.loc[state, "freq"])
                             prior_probs[i][
-                                str(len(allele_counter[c]))
+                                len(allele_counter[c])
                             ] = float(prob)
                             indel_to_charstate[i][
-                                str(len(allele_counter[c]))
+                                len(allele_counter[c])
                             ] = state
             else:
                 character_strings[sample].append(missing_data_state)

--- a/cassiopeia/solver/GreedySolver.py
+++ b/cassiopeia/solver/GreedySolver.py
@@ -214,7 +214,8 @@ class GreedySolver(CassiopeiaSolver.CassiopeiaSolver):
         Returns:
             A tree with duplicates added
         """
-
+        
+        character_matrix.index.name = "index"
         duplicate_groups = (
             character_matrix[character_matrix.duplicated(keep=False) == True]
             .reset_index()

--- a/test/preprocess_tests/character_matrix_test.py
+++ b/test/preprocess_tests/character_matrix_test.py
@@ -46,9 +46,9 @@ class TestCharacterMatrixFormation(unittest.TestCase):
 
         expected_df = pd.DataFrame.from_dict(
             {
-                "cellA": ["0", "0", "1", "1", "1", "1", "1", "1", "1"],
-                "cellB": ["0", "0", "2", "-", "-", "-", "-", "-", "-"],
-                "cellC": ["-", "-", "-", "-", "-", "-", "2", "1", "1"],
+                "cellA": [0, 0, 1, 1, 1, 1, 1, 1, 1],
+                "cellB": [0, 0, 2, -1, -1, -1, -1, -1, -1],
+                "cellC": [-1, -1, -1, -1, -1, -1, 2, 1, 1]
             },
             orient="index",
             columns=[f"r{i}" for i in range(1, 10)],
@@ -67,9 +67,9 @@ class TestCharacterMatrixFormation(unittest.TestCase):
 
         expected_df = pd.DataFrame.from_dict(
             {
-                "cellA": ["0", "0", "1", "1", "1", "1"],
-                "cellB": ["0", "0", "2", "-", "-", "-"],
-                "cellC": ["-", "-", "-", "2", "1", "1"],
+                "cellA": [0, 0, 1, 1, 1, 1],
+                "cellB": [0, 0, 2, -1, -1, -1],
+                "cellC": [-1, -1, -1, 2, 1, 1],
             },
             orient="index",
             columns=[f"r{i}" for i in range(1, 7)],
@@ -87,7 +87,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         self.assertEqual(character_matrix.shape[1], 2)
 
         expected_df = pd.DataFrame.from_dict(
-            {"cellA": ["1", "1"], "cellB": ["2", "-"], "cellC": ["-", "2"]},
+            {"cellA": [1, 1], "cellB": [2, -1], "cellC": [-1, 2]},
             orient="index",
             columns=[f"r{i}" for i in range(1, 3)],
         )
@@ -101,13 +101,13 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         )
 
         expected_priors_dictionary = {
-            2: {"1": 0.5, "2": 0.1},
-            3: {"1": 0.5},
-            4: {"1": 0.05},
-            5: {"1": 0.05},
-            6: {"1": 0.2, "2": 0.1},
-            7: {"1": 0.1},
-            8: {"1": 0.1},
+            2: {1: 0.5, 2: 0.1},
+            3: {1: 0.5},
+            4: {1: 0.05},
+            5: {1: 0.05},
+            6: {1: 0.2, 2: 0.1},
+            7: {1: 0.1},
+            8: {1: 0.1},
         }
 
         for char in expected_priors_dictionary.keys():
@@ -123,13 +123,13 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         )
 
         expected_state_mapping_dictionary = {
-            2: {"1": "ATC", "2": "ATA"},
-            3: {"1": "ATC"},
-            4: {"1": "AAA"},
-            5: {"1": "TTT"},
-            6: {"1": "GGG", "2": "GAA"},
-            7: {"1": "GAA"},
-            8: {"1": "ATA"},
+            2: {1: "ATC", 2: "ATA"},
+            3: {1: "ATC"},
+            4: {1: "AAA"},
+            5: {1: "TTT"},
+            6: {1: "GGG", 2: "GAA"},
+            7: {1: "GAA"},
+            8: {1: "ATA"},
         }
 
         for char in expected_state_mapping_dictionary.keys():


### PR DESCRIPTION
Quick bug fixes -- 

`GreedySolver` no longer assumes the index names is "index"
`convert_alleletable_to_character_matrix` creates character matrices that have integer values, not strings (and missing data is denoted by -1)