### PR TITLE
SharedMutationJoiner (UPGMA-like algorithm)

### DIFF
--- a/cassiopeia/data/CassiopeiaTree.py
+++ b/cassiopeia/data/CassiopeiaTree.py
@@ -23,7 +23,6 @@ import ete3
 import networkx as nx
 import numpy as np
 import pandas as pd
-import scipy
 
 from cassiopeia.data import utilities
 from cassiopeia.solver import solver_utilities
@@ -897,7 +896,6 @@ class CassiopeiaTree:
             weights,
             self.missing_state_indicator,
         )
-        dissimilarity_map = scipy.spatial.distance.squareform(dissimilarity_map)
 
         dissimilarity_map = pd.DataFrame(
             dissimilarity_map,

--- a/cassiopeia/data/CassiopeiaTree.py
+++ b/cassiopeia/data/CassiopeiaTree.py
@@ -23,6 +23,7 @@ import ete3
 import networkx as nx
 import numpy as np
 import pandas as pd
+import scipy
 
 from cassiopeia.data import utilities
 from cassiopeia.solver import solver_utilities
@@ -896,6 +897,8 @@ class CassiopeiaTree:
             weights,
             self.missing_state_indicator,
         )
+
+        dissimilarity_map = scipy.spatial.distance.squareform(dissimilarity_map)
 
         dissimilarity_map = pd.DataFrame(
             dissimilarity_map,

--- a/cassiopeia/data/utilities.py
+++ b/cassiopeia/data/utilities.py
@@ -9,6 +9,7 @@ import numba
 import numpy as np
 import pandas as pd
 import re
+import scipy
 
 from cassiopeia.preprocess import utilities as preprocessing_utilities
 
@@ -138,7 +139,7 @@ def compute_dissimilarity_map(
         missing_state_indicator: State indicating missing data
 
     Returns:
-        A dissimilarity mapping as a flattened array.
+        An n x n pairwise dissimilarity matrix.
     """
 
     nb_dissimilarity = numba.jit(dissimilarity_function, nopython=True)
@@ -174,9 +175,8 @@ def compute_dissimilarity_map(
 
         return dm
 
-    return _compute_dissimilarity_map(
-        cm, C, missing_state_indicator, nb_weights
-    )
+    flat_dissimilarity_map = _compute_dissimilarity_map(cm, C, missing_state_indicator, nb_weights)
+    return scipy.spatial.distance.squareform(flat_dissimilarity_map)
 
 
 def sample_bootstrap_character_matrices(

--- a/cassiopeia/data/utilities.py
+++ b/cassiopeia/data/utilities.py
@@ -9,7 +9,6 @@ import numba
 import numpy as np
 import pandas as pd
 import re
-import scipy
 
 from cassiopeia.preprocess import utilities as preprocessing_utilities
 
@@ -139,7 +138,7 @@ def compute_dissimilarity_map(
         missing_state_indicator: State indicating missing data
 
     Returns:
-        An n x n pairwise dissimilarity matrix.
+        A dissimilarity mapping as a flattened array.
     """
 
     nb_dissimilarity = numba.jit(dissimilarity_function, nopython=True)
@@ -175,8 +174,9 @@ def compute_dissimilarity_map(
 
         return dm
 
-    flat_dissimilarity_map = _compute_dissimilarity_map(cm, C, missing_state_indicator, nb_weights)
-    return scipy.spatial.distance.squareform(flat_dissimilarity_map)
+    return _compute_dissimilarity_map(
+        cm, C, missing_state_indicator, nb_weights
+    )
 
 
 def sample_bootstrap_character_matrices(

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -78,7 +78,7 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
         self.add_root = add_root
 
     def solve(self, cassiopeia_tree: CassiopeiaTree) -> None:
-        """A general bottom-up distance-based solver routine.
+        """Solves a tree for a general bottom-up distance-based solver routine.
 
         The general solver routine proceeds by iteratively finding pairs of
         samples to join together into a "cherry" and then reform the

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -36,6 +36,8 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
     TODO(mgjones, sprillo, rzhang): Specify functions to use for rooting, etc.
         the trees that are produced via a DistanceSolver. Add compositional
         framework.
+    TODO(mgjones, rzhang): Make the solver work with similarity maps as
+        flattened arrays
 
     Args:
         dissimilarity_function: Function that can be used to compute the

--- a/cassiopeia/solver/SharedMutationJoiningSolver.py
+++ b/cassiopeia/solver/SharedMutationJoiningSolver.py
@@ -11,6 +11,7 @@ import networkx as nx
 import numba
 import numpy as np
 import pandas as pd
+import scipy
 
 from cassiopeia.data import CassiopeiaTree
 from cassiopeia.data import utilities as data_utilities
@@ -32,6 +33,9 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
     algorithm has theoretical guarantees on correctness given a sufficiently
     large number of characters and bounds on edge lengths in the tree generative
     process.
+
+    TODO(mgjones, rzhang): Make the solver work with similarity maps as
+        flattened arrays
 
     Args:
         similarity_function: Function that can be used to compute the
@@ -94,6 +98,9 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
             weights,
             cassiopeia_tree.missing_state_indicator,
         )
+
+        similarity_map = scipy.spatial.distance.squareform(similarity_map)
+
         similarity_map = pd.DataFrame(
             similarity_map,
             index=character_matrix.index,
@@ -269,7 +276,7 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
     ) -> np.array:
         """A private, optimized function for updating similarities.
 
-        A faster implementation of updating the similarity map for the 
+        A faster implementation of updating the similarity map for the
         SharedMutationJoiner, invoked by
         `self.update_similarity_map_and_character_matrix`.
 

--- a/cassiopeia/solver/SharedMutationJoiningSolver.py
+++ b/cassiopeia/solver/SharedMutationJoiningSolver.py
@@ -34,8 +34,8 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
     process.
 
     Args:
-        dissimilarity_function: Function that can be used to compute the
-            dissimilarity between samples.
+        similarity_function: Function that can be used to compute the
+            similarity between samples.
         prior_transformation: Function to use when transforming priors into
             weights. Supports the following transformations:
                 "negative_log": Transforms each probability by the negative
@@ -45,7 +45,7 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
                     the square root of 1/p
 
     Attributes:
-        dissimilarity_function: Function used to compute dissimilarity between
+        similarity_function: Function used to compute similarity between
             samples.
         prior_transformation: Function to use when transforming priors into
             weights.
@@ -64,7 +64,7 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
         self.similarity_function = similarity_function
 
     def solve(self, cassiopeia_tree: CassiopeiaTree) -> None:
-        """The solver routine for the SharedMutationJoiningSolver.
+        """Solves a tree for the SharedMutationJoiningSolver.
 
         The solver routine calculates an n x n similarity matrix of all
         pairwise sample similarities based on a provided similarity function on
@@ -181,7 +181,9 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
     def update_similarity_map_and_character_matrix(
         self,
         character_matrix: pd.DataFrame,
-        nb_similarity_function,
+        nb_similarity_function: Callable[
+            [np.array, np.array, int, Dict[int, Dict[int, float]]], float
+        ],
         similarity_map: pd.DataFrame,
         cherry: Tuple[str, str],
         new_node: str,
@@ -259,13 +261,15 @@ class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
         character_matrix: np.array,
         similarity_map: np.array,
         lca: np.array,
-        nb_similarity_function,
+        nb_similarity_function: Callable[
+            [np.array, np.array, int, Dict[int, Dict[int, float]]], float
+        ],
         missing_state_indicator: int = -1,
         weights=None,
     ) -> np.array:
         """A private, optimized function for updating similarities.
 
-        A faster implementation of updating the similarity map for the
+        A faster implementation of updating the similarity map for the 
         SharedMutationJoiner, invoked by
         `self.update_similarity_map_and_character_matrix`.
 

--- a/cassiopeia/solver/SharedMutationJoiningSolver.py
+++ b/cassiopeia/solver/SharedMutationJoiningSolver.py
@@ -1,0 +1,298 @@
+"""
+This file stores the SharedMutationJoiningSolver. The inference procedure is 
+an agglomerative clustering procedure that joins samples that share the most
+identical character/state mutations.
+"""
+
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+import abc
+import networkx as nx
+import numba
+import numpy as np
+import pandas as pd
+
+from cassiopeia.data import CassiopeiaTree
+from cassiopeia.data import utilities as data_utilities
+from cassiopeia.solver import CassiopeiaSolver, solver_utilities
+
+
+class SharedMutationJoiningSolverError(Exception):
+    """An Exception class for SharedMutationJoiningSolver."""
+
+    pass
+
+
+class SharedMutationJoiningSolver(CassiopeiaSolver.CassiopeiaSolver):
+    """Shared-Mutation-Joining class for Cassiopeia.
+
+    Implements an iterative, bottom-up agglomerative clustering procedure. The
+    algorithm iteratively clusters the samples in the sample pool by the number
+    of shared mutations that they have in their character information. The
+    algorithm has theoretical guarantees on correctness given a sufficiently
+    large number of characters and bounds on edge lengths in the tree generative
+    process.
+
+    Args:
+        dissimilarity_function: Function that can be used to compute the
+            dissimilarity between samples.
+        prior_transformation: Function to use when transforming priors into
+            weights. Supports the following transformations:
+                "negative_log": Transforms each probability by the negative
+                    log (default)
+                "inverse": Transforms each probability p by taking 1/p
+                "square_root_inverse": Transforms each probability by the
+                    the square root of 1/p
+
+    Attributes:
+        dissimilarity_function: Function used to compute dissimilarity between
+            samples.
+        prior_transformation: Function to use when transforming priors into
+            weights.
+    """
+
+    def __init__(
+        self,
+        similarity_function: Callable[
+            [np.array, np.array, int, Dict[int, Dict[int, float]]], float
+        ],
+        prior_transformation: str = "negative_log",
+    ):
+
+        super().__init__(prior_transformation)
+
+        self.similarity_function = similarity_function
+
+    def solve(self, cassiopeia_tree: CassiopeiaTree) -> None:
+        """The solver routine for the SharedMutationJoiningSolver.
+
+        The solver routine calculates an n x n similarity matrix of all
+        pairwise sample similarities based on a provided similarity function on
+        the character vectors. The general solver routine proceeds by
+        iteratively finding pairs of samples to join together into a "cherry"
+        until all samples are joined. At each iterative step, the two samples
+        with the most shared character/state mutations are joined. Then, an LCA
+        node with a character vector containing only the mutations shared by the
+        joined samples is added to the sample pool, and the similarity matrix is
+        updated with respect to the new LCA node. The function will update the
+        `tree` attribute of the input CassiopeiaTree.
+
+        Args:
+            cassiopeia_tree: CassiopeiaTree object to be populated
+        """
+        character_matrix = cassiopeia_tree.get_current_character_matrix()
+        weights = None
+        if cassiopeia_tree.priors:
+            weights = solver_utilities.transform_priors(
+                cassiopeia_tree.priors, self.prior_transformation
+            )
+
+        similarity_map = data_utilities.compute_dissimilarity_map(
+            character_matrix.to_numpy(),
+            character_matrix.shape[0],
+            self.similarity_function,
+            weights,
+            cassiopeia_tree.missing_state_indicator,
+        )
+        similarity_map = pd.DataFrame(
+            similarity_map,
+            index=character_matrix.index,
+            columns=character_matrix.index,
+        )
+
+        N = similarity_map.shape[0]
+
+        identifier_to_sample = dict(
+            zip([str(i) for i in range(N)], similarity_map.index)
+        )
+
+        # Numba-ize the similarity function and weights
+        nb_similarity_function = numba.jit(
+            self.similarity_function, nopython=True
+        )
+        nb_weights = numba.typed.Dict.empty(
+            numba.types.int64,
+            numba.types.DictType(numba.types.int64, numba.types.float64),
+        )
+        if weights:
+            for k, v in weights.items():
+                nb_char_weights = numba.typed.Dict.empty(
+                    numba.types.int64, numba.types.float64
+                )
+                for state, prior in v.items():
+                    nb_char_weights[state] = prior
+                nb_weights[k] = nb_char_weights
+
+        # instantiate a tree where all samples appear as leaves.
+        tree = nx.DiGraph()
+        tree.add_nodes_from(similarity_map.index)
+
+        while N > 1:
+
+            i, j = self.find_cherry(similarity_map.values)
+
+            # get indices in the similarity matrix to join
+            node_i, node_j = (
+                similarity_map.index[i],
+                similarity_map.index[j],
+            )
+
+            new_node_name = str(len(tree.nodes))
+            tree.add_node(new_node_name)
+            tree.add_edges_from(
+                [(new_node_name, node_i), (new_node_name, node_j)]
+            )
+
+            similarity_map = self.update_similarity_map_and_character_matrix(
+                character_matrix,
+                nb_similarity_function,
+                similarity_map,
+                (node_i, node_j),
+                new_node_name,
+                cassiopeia_tree.missing_state_indicator,
+                nb_weights,
+            )
+
+            N = similarity_map.shape[0]
+
+        tree = nx.relabel_nodes(tree, identifier_to_sample)
+
+        cassiopeia_tree.populate_tree(tree)
+
+    def find_cherry(self, similarity_matrix: np.array) -> Tuple[int, int]:
+        """Finds a pair of samples to join into a cherry.
+
+        Finds the pair of samples with the highest pairwise similarity to join.
+
+        Args:
+            similarity_matrix: A sample x sample similarity matrix
+
+        Returns:
+            A tuple of integers representing rows in the similarity matrix
+            to join.
+        """
+        similarity_matrix = similarity_matrix.astype(float)
+        np.fill_diagonal(similarity_matrix, -np.inf)
+
+        return np.unravel_index(
+            np.argmax(similarity_matrix, axis=None), similarity_matrix.shape
+        )
+
+    def update_similarity_map_and_character_matrix(
+        self,
+        character_matrix: pd.DataFrame,
+        nb_similarity_function,
+        similarity_map: pd.DataFrame,
+        cherry: Tuple[str, str],
+        new_node: str,
+        missing_state_indicator: int = -1,
+        weights=None,
+    ) -> pd.DataFrame:
+        """Update similarity map after finding a cherry.
+
+        Adds the new LCA node into the character matrix with the mutations
+        shared by the joined nodes as its character vector. Then, updates the
+        similarity matrix by calculating the pairwise similarity between the
+        new LCA node and all existing nodes.
+
+        Args:
+            character_matrix: Contains the character information for all nodes,
+                updated as nodes are joined and new internal LCA nodes are added
+            nb_similarity: A numba compiled similarity function
+            similarity_map: A similarity map to update
+            cherry: A tuple of indices in the similarity map that are joining
+            new_node: New node name, to be added to the updated similarity map
+            missing_state_indicator: Character representing missing data
+            weights: Weighting of each (character, state) pair. Typically a
+                transformation of the priors.
+
+        Returns:
+            A new similarity map, updated with the new node
+        """
+
+        character_i, character_j = (
+            np.where(character_matrix.index == cherry[0])[0][0],
+            np.where(character_matrix.index == cherry[1])[0][0],
+        )
+
+        character_array = character_matrix.to_numpy(copy=True)
+        similarity_array = similarity_map.to_numpy()
+        i_characters = character_array[character_i, :]
+        j_characters = character_array[character_j, :]
+        lca = data_utilities.get_lca_characters(
+            [i_characters, j_characters], missing_state_indicator
+        )
+        character_matrix.loc[new_node] = lca
+
+        similarity_array_updated = self.__update_similarity_map_numba(
+            character_array,
+            similarity_array,
+            np.array(lca),
+            nb_similarity_function,
+            missing_state_indicator,
+            weights,
+        )
+
+        sample_names = list(similarity_map.index) + [new_node]
+
+        similarity_map = pd.DataFrame(
+            similarity_array_updated, index=sample_names, columns=sample_names
+        )
+
+        # drop out cherry from similarity map and character matrix
+        similarity_map.drop(
+            columns=[cherry[0], cherry[1]],
+            index=[cherry[0], cherry[1]],
+            inplace=True,
+        )
+
+        character_matrix.drop(
+            index=[cherry[0], cherry[1]],
+            inplace=True,
+        )
+
+        return similarity_map
+
+    @staticmethod
+    @numba.jit(nopython=True)
+    def __update_similarity_map_numba(
+        character_matrix: np.array,
+        similarity_map: np.array,
+        lca: np.array,
+        nb_similarity_function,
+        missing_state_indicator: int = -1,
+        weights=None,
+    ) -> np.array:
+        """A private, optimized function for updating similarities.
+
+        A faster implementation of updating the similarity map for the
+        SharedMutationJoiner, invoked by
+        `self.update_similarity_map_and_character_matrix`.
+
+        Args:
+            character_matrix: The character information for all nodes
+            similarity_map: A matrix of similarities to update
+            lca: The character vector of the new LCA node
+            nb_similarity_function: A numba compiled similarity function
+            missing_state_indicator: Character representing missing data
+            weights: Weighting of each (character, state) pair. Typically a
+                transformation of the priors.
+
+        Returns:
+            An updated similarity map
+        """
+
+        C = similarity_map.shape[0]
+        new_row = np.zeros(C, dtype=numba.float64)
+        k = 0
+        for i in range(C):
+            s1 = character_matrix[i, :]
+            new_row[k] = nb_similarity_function(
+                s1, lca, missing_state_indicator, weights
+            )
+            k += 1
+
+        updated_map = np.vstack((similarity_map, np.atleast_2d(new_row)))
+        new_col = np.append(new_row, np.array([0]))
+        updated_map = np.hstack((updated_map, np.atleast_2d(new_col).T))
+        return updated_map

--- a/test/solver_tests/sharedmutationjoiner_test.py
+++ b/test/solver_tests/sharedmutationjoiner_test.py
@@ -1,0 +1,426 @@
+"""
+Test SharedMutationJoiningSolver in Cassiopeia.solver.
+"""
+import os
+import unittest
+from typing import Dict, Optional
+
+import itertools
+import networkx as nx
+import numba
+import numpy as np
+import pandas as pd
+
+from cassiopeia.data.CassiopeiaTree import CassiopeiaTree
+from cassiopeia.data import utilities as data_utilities
+from cassiopeia.solver.SharedMutationJoiningSolver import (
+    SharedMutationJoiningSolver,
+)
+from cassiopeia.solver import dissimilarity_functions
+from cassiopeia.solver import solver_utilities
+
+
+def find_triplet_structure(triplet, T):
+    a, b, c = triplet[0], triplet[1], triplet[2]
+    a_ancestors = [node for node in nx.ancestors(T, a)]
+    b_ancestors = [node for node in nx.ancestors(T, b)]
+    c_ancestors = [node for node in nx.ancestors(T, c)]
+    ab_common = len(set(a_ancestors) & set(b_ancestors))
+    ac_common = len(set(a_ancestors) & set(c_ancestors))
+    bc_common = len(set(b_ancestors) & set(c_ancestors))
+    structure = "-"
+    if ab_common > bc_common and ab_common > ac_common:
+        structure = "ab"
+    elif ac_common > bc_common and ac_common > ab_common:
+        structure = "ac"
+    elif bc_common > ab_common and bc_common > ac_common:
+        structure = "bc"
+    return structure
+
+
+class TestSharedMutationJoiningSolver(unittest.TestCase):
+    def setUp(self):
+
+        # --------------------- General NJ ---------------------
+        cm = pd.DataFrame.from_dict(
+            {
+                "a": [0, 1, 2],
+                "b": [1, 1, 2],
+                "c": [2, 2, 2],
+                "d": [1, 1, 1],
+                "e": [0, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        delta = pd.DataFrame.from_dict(
+            {
+                "a": [0, 2, 1, 1, 0],
+                "b": [2, 0, 1, 2, 0],
+                "c": [1, 1, 0, 0, 0],
+                "d": [1, 2, 0, 0, 0],
+                "e": [0, 0, 0, 0, 0],
+            },
+            orient="index",
+            columns=["a", "b", "c", "d", "e"],
+        )
+
+        self.basic_similarity_map = delta
+        self.basic_tree = CassiopeiaTree(
+            character_matrix=cm,
+            dissimilarity_map=delta,
+        )
+
+        self.smj_solver = SharedMutationJoiningSolver(
+            similarity_function=dissimilarity_functions.hamming_similarity_without_missing
+        )
+
+        # ---------------- Lineage Tracing NJ ----------------
+
+        pp_cm = pd.DataFrame.from_dict(
+            {
+                "a": [1, 2, 2],
+                "b": [1, 2, 1],
+                "c": [1, 2, 0],
+                "d": [2, 0, 0],
+                "e": [2, 0, 2],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        self.pp_tree = CassiopeiaTree(character_matrix=pp_cm)
+
+        self.smj_solver_pp = SharedMutationJoiningSolver(
+            similarity_function=dissimilarity_functions.hamming_similarity_without_missing
+        )
+
+        # ------------- CM with Duplicates and Missing Data -----------------------
+        duplicates_cm = pd.DataFrame.from_dict(
+            {
+                "a": [1, -1, 0],
+                "b": [2, -1, 2],
+                "c": [2, 0, 2],
+                "d": [2, 0, -1],
+                "e": [2, 0, 2],
+                "f": [2, -1, 2],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        self.duplicate_tree = CassiopeiaTree(character_matrix=duplicates_cm)
+
+        # ------------- Hamming similarity with weights ------------
+        priors = {0: {1: 0.5, 2: 0.5}, 1: {1: 0.2, 2: 0.8}, 2: {1: 0.9, 2: 0.1}}
+        self.pp_tree_priors = CassiopeiaTree(
+            character_matrix=pp_cm, priors=priors
+        )
+        self.smj_solver_modified_pp = SharedMutationJoiningSolver(
+            similarity_function=dissimilarity_functions.hamming_similarity_without_missing
+        )
+
+    def test_find_cherry(self):
+        cherry = self.smj_solver.find_cherry(self.basic_similarity_map.values)
+        delta = self.basic_similarity_map
+        node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+
+        self.assertIn((node_i, node_j), [("a", "b"), ("b", "a")])
+
+    def test_create_similarity_map(self):
+        character_matrix = self.pp_tree_priors.get_current_character_matrix()
+        weights = solver_utilities.transform_priors(
+            self.pp_tree_priors.priors, "negative_log"
+        )
+
+        similarity_map = data_utilities.compute_dissimilarity_map(
+            character_matrix.to_numpy(),
+            character_matrix.shape[0],
+            dissimilarity_functions.hamming_similarity_without_missing,
+            weights,
+            self.pp_tree_priors.missing_state_indicator,
+        )
+        similarity_map = pd.DataFrame(
+            similarity_map,
+            index=character_matrix.index,
+            columns=character_matrix.index,
+        )
+
+        expected_similarity = -np.log(0.5) - np.log(0.8)
+        self.assertEqual(similarity_map.loc["a", "b"], expected_similarity)
+        expected_similarity = -np.log(0.1)
+        self.assertEqual(similarity_map.loc["a", "e"], expected_similarity)
+
+    def test_update_similarity_map_and_character_matrix(self):
+
+        nb_similarity = numba.jit(
+            dissimilarity_functions.hamming_similarity_without_missing,
+            nopython=True,
+        )
+        nb_weights = numba.typed.Dict.empty(
+            numba.types.int64,
+            numba.types.DictType(numba.types.int64, numba.types.float64),
+        )
+
+        cm = self.basic_tree.get_current_character_matrix()
+        delta = self.basic_similarity_map
+
+        cherry = self.smj_solver.find_cherry(delta.values)
+        node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+
+        delta = self.smj_solver.update_similarity_map_and_character_matrix(
+            cm, nb_similarity, delta, (node_i, node_j), "ab", weights=nb_weights
+        )
+
+        expected_delta = pd.DataFrame.from_dict(
+            {
+                "ab": [0, 1, 1, 0],
+                "c": [1, 0, 0, 0],
+                "d": [1, 0, 0, 0],
+                "e": [0, 0, 0, 0],
+            },
+            orient="index",
+            columns=["ab", "c", "d", "e"],
+        )
+
+        for sample in expected_delta.index:
+            for sample2 in expected_delta.index:
+                self.assertEqual(
+                    delta.loc[sample, sample2],
+                    expected_delta.loc[sample, sample2],
+                )
+
+        cherry = self.smj_solver.find_cherry(delta.values)
+        node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+
+        delta = self.smj_solver.update_similarity_map_and_character_matrix(
+            cm,
+            nb_similarity,
+            delta,
+            (node_i, node_j),
+            "abc",
+            weights=nb_weights,
+        )
+
+        expected_delta = pd.DataFrame.from_dict(
+            {
+                "abc": [0, 0, 0],
+                "d": [0, 0, 0],
+                "e": [0, 0, 0],
+            },
+            orient="index",
+            columns=["abc", "d", "e"],
+        )
+
+        for sample in expected_delta.index:
+            for sample2 in expected_delta.index:
+                self.assertEqual(
+                    delta.loc[sample, sample2],
+                    expected_delta.loc[sample, sample2],
+                )
+
+        expected_cm = pd.DataFrame.from_dict(
+            {
+                "abc": [0, 0, 2],
+                "d": [1, 1, 1],
+                "e": [0, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        for sample in expected_cm.index:
+            for col in expected_cm.columns:
+                self.assertEqual(
+                    cm.loc[sample, col],
+                    expected_cm.loc[sample, col],
+                )
+
+    def test_basic_solver(self):
+
+        self.smj_solver.solve(self.basic_tree)
+
+        # test that the dissimilarity map and character matrix were not altered
+        cm = pd.DataFrame.from_dict(
+            {
+                "a": [0, 1, 2],
+                "b": [1, 1, 2],
+                "c": [2, 2, 2],
+                "d": [1, 1, 1],
+                "e": [0, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+        for i in self.basic_similarity_map.index:
+            for j in self.basic_similarity_map.columns:
+                self.assertEqual(
+                    self.basic_similarity_map.loc[i, j],
+                    self.basic_tree.get_dissimilarity_map().loc[i, j],
+                )
+        for i in self.basic_tree.get_current_character_matrix().index:
+            for j in self.basic_tree.get_current_character_matrix().columns:
+                self.assertEqual(
+                    cm.loc[i, j],
+                    self.basic_tree.get_current_character_matrix().loc[i, j],
+                )
+
+        # test leaves exist in tree
+        _leaves = self.basic_tree.leaves
+
+        self.assertEqual(len(_leaves), self.basic_similarity_map.shape[0])
+        for _leaf in _leaves:
+            self.assertIn(_leaf, self.basic_similarity_map.index.values)
+
+        # test for expected number of edges
+        edges = list(self.basic_tree.edges)
+        self.assertEqual(len(edges), 8)
+
+        # test relationships between samples
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
+            ["a", "b", "c", "d", "e", "5", "6", "7", "8"]
+        )
+        expected_tree.add_edges_from(
+            [
+                ("5", "a"),
+                ("5", "b"),
+                ("6", "5"),
+                ("6", "c"),
+                ("7", "d"),
+                ("7", "e"),
+                ("8", "6"),
+                ("8", "7"),
+            ]
+        )
+
+        T = self.basic_tree.get_tree_topology()
+        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+        for triplet in triplets:
+
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, T)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+        # compare tree distances
+        T = T.to_undirected()
+        expected_tree = expected_tree.to_undirected()
+        for i in range(len(_leaves)):
+            sample1 = _leaves[i]
+            for j in range(i + 1, len(_leaves)):
+                sample2 = _leaves[j]
+                self.assertEqual(
+                    nx.shortest_path_length(T, sample1, sample2),
+                    nx.shortest_path_length(expected_tree, sample1, sample2),
+                )
+
+    def test_smj_solver_weights(self):
+
+        self.smj_solver_modified_pp.solve(self.pp_tree_priors)
+        T = self.pp_tree_priors.get_tree_topology()
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
+            ["a", "b", "c", "d", "e", "5", "6", "7", "8"]
+        )
+        expected_tree.add_edges_from(
+            [
+                ("5", "a"),
+                ("5", "e"),
+                ("6", "b"),
+                ("6", "c"),
+                ("7", "5"),
+                ("7", "d"),
+                ("8", "6"),
+                ("8", "7"),
+            ]
+        )
+
+        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, T)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+    def test_pp_solver(self):
+
+        self.smj_solver_pp.solve(self.pp_tree)
+        T = self.pp_tree.get_tree_topology()
+
+        pp_cm = pd.DataFrame.from_dict(
+            {
+                "a": [1, 2, 2],
+                "b": [1, 2, 1],
+                "c": [1, 2, 0],
+                "d": [2, 0, 0],
+                "e": [2, 0, 2],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+        self.assertIsNone(self.pp_tree.get_dissimilarity_map())
+        for i in self.pp_tree.get_current_character_matrix().index:
+            for j in self.pp_tree.get_current_character_matrix().columns:
+                self.assertEqual(
+                    pp_cm.loc[i, j],
+                    self.pp_tree.get_current_character_matrix().loc[i, j],
+                )
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
+            ["a", "b", "c", "d", "e", "5", "6", "7", "8"]
+        )
+        expected_tree.add_edges_from(
+            [
+                ("5", "a"),
+                ("5", "b"),
+                ("6", "5"),
+                ("6", "c"),
+                ("7", "d"),
+                ("7", "e"),
+                ("8", "6"),
+                ("8", "7"),
+            ]
+        )
+
+        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, T)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+    def test_duplicate(self):
+        # In this case, we see that the missing data can break up a duplicate
+        # pair if the behavior is to ignore missing data
+
+        self.smj_solver_pp.solve(self.duplicate_tree)
+        T = self.duplicate_tree.get_tree_topology()
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
+            ["a", "b", "c", "d", "e", "f", "5", "6", "7", "8", "9"]
+        )
+        expected_tree.add_edges_from(
+            [
+                ("5", "b"),
+                ("5", "c"),
+                ("6", "e"),
+                ("6", "f"),
+                ("7", "5"),
+                ("7", "6"),
+                ("8", "7"),
+                ("8", "d"),
+                ("9", "8"),
+                ("9", "a"),
+            ]
+        )
+        triplets = itertools.combinations(["a", "b", "c", "d", "e", "f"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, T)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/solver_tests/sharedmutationjoiner_test.py
+++ b/test/solver_tests/sharedmutationjoiner_test.py
@@ -10,6 +10,7 @@ import networkx as nx
 import numba
 import numpy as np
 import pandas as pd
+import scipy
 
 from cassiopeia.data.CassiopeiaTree import CassiopeiaTree
 from cassiopeia.data import utilities as data_utilities
@@ -141,6 +142,9 @@ class TestSharedMutationJoiningSolver(unittest.TestCase):
             weights,
             self.pp_tree_priors.missing_state_indicator,
         )
+
+        similarity_map = scipy.spatial.distance.squareform(similarity_map)
+
         similarity_map = pd.DataFrame(
             similarity_map,
             index=character_matrix.index,


### PR DESCRIPTION
Hi Matt and Sebastian,
Here is the SMJ (working title for the UPGMA-like algorithm).

I also made it so that the conversion from the numba calculated flattened array to the square nxn dissimilarity map happens inside the utilities.compute_dissimilarity_map function, as I thought it was more natural for it to handle this conversion.

Additionally, the function does not make use of the compute_dissimilarity_map function found in CassiopeiaTree as I felt we do not want to override the dissimilarity map in the Tree. This is due to the fact that the algorithm calculates a similarity map and not a dissimilarity map and this may cause some confusion. 

Please let me know what you think! Thanks in advance for your feedback.