### PR TITLE
fix sort_cellranger_bam chunked sorting

### DIFF
--- a/cassiopeia/preprocess/UMI_utils.py
+++ b/cassiopeia/preprocess/UMI_utils.py
@@ -1,7 +1,7 @@
 """
 This file contains all functions pertaining to UMI collapsing and preprocessing.
-Invoked through pipeline.py and supports the collapseUMIs and 
-errorCorrectUMIs functions. 
+Invoked through pipeline.py and supports the collapseUMIs and
+errorCorrectUMIs functions.
 """
 import os
 
@@ -95,7 +95,7 @@ def sort_cellranger_bam(
     """
     Path(sorted_fn).parent.mkdir(exist_ok=True)
 
-    bam_fh = pysam.AlignmentFile(str(bam_fp))
+    bam_fh = pysam.AlignmentFile(str(bam_fp), check_sq=False)
 
     relevant = filter(filter_func, bam_fh)
 

--- a/cassiopeia/preprocess/UMI_utils.py
+++ b/cassiopeia/preprocess/UMI_utils.py
@@ -109,13 +109,12 @@ def sort_cellranger_bam(
         chunk_fn = Path(sorted_fn).with_suffix(suffix)
         sorted_chunk = sorted(chunk, key=sort_key)
 
-    with pysam.AlignmentFile(str(chunk_fn), "wb", template=bam_fh) as fh:
-        for al in sorted_chunk:
-            max_read_length = max(max_read_length, al.query_length)
-            total_reads_out += 1
-            fh.write(al)
-
-    chunk_fns.append(chunk_fn)
+        with pysam.AlignmentFile(str(chunk_fn), "wb", template=bam_fh) as fh:
+            for al in sorted_chunk:
+                max_read_length = max(max_read_length, al.query_length)
+                total_reads_out += 1
+                fh.write(al)
+        chunk_fns.append(chunk_fn)
 
     chunk_fhs = [
         pysam.AlignmentFile(str(fn), check_header=False, check_sq=False)


### PR DESCRIPTION
Hi!
I've been using Cassiopeia to preprocess BAM files that were manually generated (manually tagged with CB and UR; all reads unmapped). The BAM file contains 10729723 reads.
When `cassiopeia.pp.UMI_utils.sort_cellranger_bam` is called from `cassiopeia.pp.collapse_umis`, the chunk loop is not appropriately indented, so only the last chunk is processed.
https://github.com/YosefLab/Cassiopeia/blob/30907209afefbbf353383d8fea30708d7b43ac7d/cassiopeia/preprocess/UMI_utils.py#L105-L118

In my case, only the last 729723 reads are processed (and the other chunk with 10M reads is discarded). This PR fixes this issue.

Additionally, I've added `check_sq=False` to https://github.com/YosefLab/Cassiopeia/blob/30907209afefbbf353383d8fea30708d7b43ac7d/cassiopeia/preprocess/UMI_utils.py#L98
to allow unmapped BAMs.