### PR TITLE
Update iTOL plotting function + minor fix

### DIFF
--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -96,6 +96,8 @@ def upload_and_export_itol(
         random_state: A random state for reproducibility
         files: Additional files to upload
         verbose: Include extra print statements.
+        **kwargs: additional keyword arguments are passed as iTOL export parameters.
+            See https://itol.embl.de/help.cgi#batch for a full list.
 
     Raises:
         iTOLError if iTOL credentials cannot be found, if the output format is

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -45,7 +45,7 @@ def upload_and_export_itol(
     use_branch_lengths: bool = False,
     palette: List[str] = palettes.Category20[20],
     random_state: Optional[np.random.RandomState] = None,
-    files: Optional[List[str]] = None,
+    dataset_files: Optional[List[str]] = None,
     verbose: bool = True,
     **kwargs
 ):
@@ -94,7 +94,9 @@ def upload_and_export_itol(
         include_legend: Plot legend along with meta data.
         palette: A palette of colors in hex format.
         random_state: A random state for reproducibility
-        files: Additional files to upload
+        user_dataset_files: List of paths to additional dataset files to upload.
+            See https://itol.embl.de/help.cgi#dsType for available dataset types
+            and their definitions.
         verbose: Include extra print statements.
         **kwargs: additional keyword arguments are passed as iTOL export parameters.
             See https://itol.embl.de/help.cgi#batch for a full list.
@@ -143,7 +145,7 @@ def upload_and_export_itol(
         os.path.join(temporary_directory, "tree_to_plot.tree")
     )
 
-    files = files.copy() if files else []
+    files = user_dataset_files.copy() if user_dataset_files else []
     if allele_table is not None:
         files += create_indel_heatmap(
             allele_table,

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -229,7 +229,7 @@ def upload_and_export_itol(
     itol_exporter.set_export_param_value("horizontal_scale_factor", 1)
 
     for key, value in kwargs.items():
-        itol_exporter.set_export_param_value(kwargs, value)
+        itol_exporter.set_export_param_value(key, value)
 
     # export!
     itol_exporter.export(export_filepath)

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -45,7 +45,7 @@ def upload_and_export_itol(
     use_branch_lengths: bool = False,
     palette: List[str] = palettes.Category20[20],
     random_state: Optional[np.random.RandomState] = None,
-    dataset_files: Optional[List[str]] = None,
+    user_dataset_files: Optional[List[str]] = None,
     verbose: bool = True,
     **kwargs
 ):

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -46,6 +46,7 @@ def upload_and_export_itol(
     palette: List[str] = palettes.Category20[20],
     random_state: Optional[np.random.RandomState] = None,
     verbose: bool = True,
+    **kwargs
 ):
     """Uploads a tree to iTOL and exports it.
 
@@ -84,7 +85,7 @@ def upload_and_export_itol(
         indel_colors: Color mapping to use for plotting the alleles for each
             cell. Only necessary if `allele_table` is specified.
         indel_priors: Prior probabilities for each indel. Only useful if an
-            allele table is to be plotted and `indel_colors` is None.           
+            allele table is to be plotted and `indel_colors` is None.
         rect: Boolean indicating whether or not to save your tree as a circle
             or rectangle.
         use_branch_lengths: Whether or not to use branch lengths when exporting
@@ -105,7 +106,7 @@ def upload_and_export_itol(
 
     if (api_key is None or project_name is None):
         if os.path.exists(os.path.expanduser(itol_config)):
-        
+
             config = configparser.ConfigParser()
             with open(os.path.expanduser(itol_config), "r") as f:
                 config_string = f.read()
@@ -226,6 +227,9 @@ def upload_and_export_itol(
     )
 
     itol_exporter.set_export_param_value("horizontal_scale_factor", 1)
+
+    for key, value in kwargs.items():
+        itol_exporter.set_export_param_value(kwargs, value)
 
     # export!
     itol_exporter.export(export_filepath)
@@ -618,9 +622,9 @@ def hex_to_rgb(value) -> Tuple[int, int, int]:
 
     Args:
         values: hex values (beginning with "#")
-    
+
     Returns:
-        A tuple denoting (r, g, b) 
+        A tuple denoting (r, g, b)
     """
     value = value.lstrip("#")
     lv = len(value)
@@ -648,7 +652,7 @@ def generate_random_color(
     random_state: Optional[np.random.RandomState] = None,
 ) -> Tuple[int, int, int]:
     """Generates a random color from ranges of RGB.
-    
+
     Args:
         r_range: Range of values for the R value
         g_range: Range of value for the G value

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -45,6 +45,7 @@ def upload_and_export_itol(
     use_branch_lengths: bool = False,
     palette: List[str] = palettes.Category20[20],
     random_state: Optional[np.random.RandomState] = None,
+    files: Optional[List[str]] = None,
     verbose: bool = True,
     **kwargs
 ):
@@ -93,6 +94,7 @@ def upload_and_export_itol(
         include_legend: Plot legend along with meta data.
         palette: A palette of colors in hex format.
         random_state: A random state for reproducibility
+        files: Additional files to upload
         verbose: Include extra print statements.
 
     Raises:
@@ -139,7 +141,7 @@ def upload_and_export_itol(
         os.path.join(temporary_directory, "tree_to_plot.tree")
     )
 
-    files = []
+    files = files.copy() if files else []
     if allele_table is not None:
         files += create_indel_heatmap(
             allele_table,

--- a/cassiopeia/preprocess/pipeline.py
+++ b/cassiopeia/preprocess/pipeline.py
@@ -570,7 +570,7 @@ def filter_molecule_table(
     t0 = time.time()
     logging.info("Begin filtering reads...")
     input_df["status"] = "good"
-    input_df.sort_values("readCount", ascending=False)
+    input_df.sort_values("readCount", ascending=False, inplace=True)
     rc_profile, upi_profile, upc_profile = {}, {}, {}
     utilities.generate_log_output(input_df, begin=True)
 


### PR DESCRIPTION
I've added a new argument `files` to `upload_and_export_itol` function that can be used to upload additional custom datasets. Also, any keyword arguments provided to the function are now considered as iTOL export parameters. This change makes it easier to customize the iTOL export a bit more than is currently allowed.

Also, a small fix where a dataframe was not being sorted inplace.