### PR TITLE
test fixes for python 3.8 and newer numpy versions

### DIFF
--- a/cassiopeia/data/CassiopeiaTree.py
+++ b/cassiopeia/data/CassiopeiaTree.py
@@ -6,8 +6,8 @@ clonal population (though this is not required). Other important data is also
 stored here, like the priors for given character states as well any meta data
 associated with this clonal  population.
 
-When a solver has been called on this object, a tree will be added to the data 
-structure at which point basic properties can be queried like the average tree 
+When a solver has been called on this object, a tree will be added to the data
+structure at which point basic properties can be queried like the average tree
 depth or agreement between character states and phylogeny.
 
 This object can be passed to any CassiopeiaSolver subclass as well as any
@@ -464,7 +464,7 @@ class CassiopeiaTree:
         Reconstructs ancestral states (i.e., those character states in the
         internal nodes) using the Camin-Sokal parsimony criterion (i.e.,
         irreversibility). Operates on the tree in place.
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -518,7 +518,7 @@ class CassiopeiaTree:
 
     def __remove_node(self, node) -> None:
         """Private method to remove node from tree.
-        
+
         Args:
             node: A node in the tree to be removed
 
@@ -528,27 +528,27 @@ class CassiopeiaTree:
         self.__check_network_initialized()
 
         self.__network.remove_node(node)
-    
+
     def __add_node(self, node) -> None:
         """Private method to add node to tree.
-        
+
         Args:
             node: A node to be added to the tree.
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
         self.__check_network_initialized()
-        
+
         self.__network.add_node(node)
 
     def __remove_edge(self, u, v) -> None:
         """Private method to remove edge from tree.
-        
+
         Args:
             u: The source node of the directed edge to be removed
             v: The sink node of the directed edge to be removed
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
@@ -562,7 +562,7 @@ class CassiopeiaTree:
         Args:
             u: The source node of the directed edge to be added
             v: The sink node of the directed edge to be added
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
@@ -727,12 +727,12 @@ class CassiopeiaTree:
         Adjusts the branch length of specified parent-child relationships.
         This procedure maintains the consistency with the rest of the times in
         the tree. Namely, by changing branch lengths here, it will change
-        the times of all the nodes in the tree such that the times are 
+        the times of all the nodes in the tree such that the times are
         representative of the new branch lengths.
 
         Args:
             branch_dict: A dictionary of edges to updated branch lengths
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -867,7 +867,7 @@ class CassiopeiaTree:
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
-    
+
         self.__check_network_initialized()
 
         if source is None:
@@ -898,7 +898,7 @@ class CassiopeiaTree:
 
     def get_newick(self, record_branch_lengths = False) -> str:
         """Returns newick format of tree.
-        
+
         Args:
             record_branch_lengths: Whether to record branch lengths on the tree
             in the newick string
@@ -915,7 +915,7 @@ class CassiopeiaTree:
 
     def get_tree_topology(self) -> nx.DiGraph:
         """Returns the tree in Networkx format.
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -1014,7 +1014,7 @@ class CassiopeiaTree:
 
         Removes a leaf and all ancestors of that leaf that are no longer the
         ancestor of any leaves. In the context of a phylogeny, this prunes the
-        lineage of all nodes no longer relevant to observed samples. 
+        lineage of all nodes no longer relevant to observed samples.
         Additionally, maintains consistency with information on the tree by
         removing the node from the character matrix and cell metadata.
 
@@ -1109,16 +1109,16 @@ class CassiopeiaTree:
         """Collapses mutationless edges in the tree in-place.
 
         Uses the internal node annotations of a tree to collapse edges with no
-        mutations. The introduction of a missing data event is considered a 
+        mutations. The introduction of a missing data event is considered a
         mutation in this context. Either takes the existing character states on
-        the tree or infers the annotations bottom-up from the samples obeying 
+        the tree or infers the annotations bottom-up from the samples obeying
         Camin-Sokal Parsimony. Preserves the times of nodes that are not removed
-        by connecting the parent and children of removed nodes by branchs with 
+        by connecting the parent and children of removed nodes by branchs with
         lengths equal to the total time elapsed from parent to each child.
 
         Args:
             tree: A networkx DiGraph object representing the tree
-            infer_ancestral_characters: Infer the ancestral characters states 
+            infer_ancestral_characters: Infer the ancestral characters states
                 of the tree
 
         Raises:
@@ -1238,7 +1238,7 @@ class CassiopeiaTree:
 
     def set_attribute(self, node: str, attribute_name: str, value: Any) -> None:
         """Sets an attribute in the tree.
-        
+
         Args:
             node: Node name
             attribute_name: Name for the new attribute
@@ -1253,11 +1253,11 @@ class CassiopeiaTree:
 
     def get_attribute(self, node: str, attribute_name: str) -> Any:
         """Retrieves the value of an attribute for a node.
-        
+
         Args:
             node: Node name
             attribute_name: Name of the attribute.
-        
+
         Returns:
             The value of the attribute for that node.
 
@@ -1269,7 +1269,7 @@ class CassiopeiaTree:
         try:
             return self.__network.nodes[node][attribute_name]
         except KeyError:
-            raise CassiopeiaTreeError(f"Attribute {attribute_name} not " 
+            raise CassiopeiaTreeError(f"Attribute {attribute_name} not "
                                     "detected for this node.")
 
     def filter_nodes(self, condition: Callable[[str], bool]) -> List[str]:

--- a/test/preprocess_tests/character_matrix_test.py
+++ b/test/preprocess_tests/character_matrix_test.py
@@ -254,7 +254,6 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         lineage_profile = cas.pp.convert_alleletable_to_lineage_profile(
             self.alleletable_basic
         )
-
         (
             character_matrix,
             priors,
@@ -274,12 +273,31 @@ class TestCharacterMatrixFormation(unittest.TestCase):
             columns=[f"r{i}" for i in range(9)],
         )
         expected_character_matrix.index.name = "cellBC"
-
-        pd.testing.assert_frame_equal(
-            expected_character_matrix, character_matrix
+        # Behavior on ties is different depending on the numpy version. So we
+        # need to check against two different expected character matrices.
+        # Specifically, intBC A and C are tied.
+        expected_character_matrix2 = pd.DataFrame.from_dict(
+            {
+                "cellA": [0, 0, 1, 1, 1, 1, 1, 1, 1],
+                "cellB": [0, 0, 2, -1, -1, -1, -1, -1, -1],
+                "cellC": [-1, -1, -1, 2, 1, 1, -1, -1, -1],
+            },
+            orient="index",
+            columns=[f"r{i}" for i in range(9)],
         )
+        expected_character_matrix2.index.name = "cellBC"
 
-    def test_lineage_profile_to_character_matrix_no_priors(self):
+        # Check that character_matrix is either of the two expected matrices.
+        try:
+            pd.testing.assert_frame_equal(
+                expected_character_matrix, character_matrix
+            )
+        except AssertionError as e:
+            pd.testing.assert_frame_equal(
+                expected_character_matrix2, character_matrix
+            )
+
+    def test_lineage_profile_to_character_matrix_with_priors(self):
 
         lineage_profile = cas.pp.convert_alleletable_to_lineage_profile(
             self.alleletable_basic
@@ -306,10 +324,29 @@ class TestCharacterMatrixFormation(unittest.TestCase):
             columns=[f"r{i}" for i in range(9)],
         )
         expected_character_matrix.index.name = "cellBC"
-
-        pd.testing.assert_frame_equal(
-            expected_character_matrix, character_matrix
+        # Behavior on ties is different depending on the numpy version. So we
+        # need to check against two different expected character matrices.
+        # Specifically, intBC A and C are tied.
+        expected_character_matrix2 = pd.DataFrame.from_dict(
+            {
+                "cellA": [0, 0, 1, 1, 1, 1, 1, 1, 1],
+                "cellB": [0, 0, 2, -1, -1, -1, -1, -1, -1],
+                "cellC": [-1, -1, -1, 2, 1, 1, -1, -1, -1],
+            },
+            orient="index",
+            columns=[f"r{i}" for i in range(9)],
         )
+        expected_character_matrix2.index.name = "cellBC"
+
+        # Check that character_matrix is either of the two expected matrices.
+        try:
+            pd.testing.assert_frame_equal(
+                expected_character_matrix, character_matrix
+            )
+        except AssertionError as e:
+            pd.testing.assert_frame_equal(
+                expected_character_matrix2, character_matrix
+            )
 
         # test prior dictionary formation
         for character in priors.keys():


### PR DESCRIPTION
* Fixes a `RuntimeError: dictionary keys changed during iteration` that would happen in the `collapse_unifurcations` function
* Fixes tests for newer numpy versions. When `sort_values` is called on a series, pandas internally calls `np.sort`, which handles ties differently based on numpy version.