### PR TITLE
Fix DistanceSolver adding non-unique node names

### DIFF
--- a/cassiopeia/data/CassiopeiaTree.py
+++ b/cassiopeia/data/CassiopeiaTree.py
@@ -6,8 +6,8 @@ clonal population (though this is not required). Other important data is also
 stored here, like the priors for given character states as well any meta data
 associated with this clonal  population.
 
-When a solver has been called on this object, a tree will be added to the data 
-structure at which point basic properties can be queried like the average tree 
+When a solver has been called on this object, a tree will be added to the data
+structure at which point basic properties can be queried like the average tree
 depth or agreement between character states and phylogeny.
 
 This object can be passed to any CassiopeiaSolver subclass as well as any
@@ -471,7 +471,7 @@ class CassiopeiaTree:
         Reconstructs ancestral states (i.e., those character states in the
         internal nodes) using the Camin-Sokal parsimony criterion (i.e.,
         irreversibility). Operates on the tree in place.
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -506,7 +506,7 @@ class CassiopeiaTree:
             CassiopeiaTreeError if the tree is not initialized.
         """
         self.__check_network_initialized()
-        
+
         return [u for u in self.__network.predecessors(node)][0]
 
     def children(self, node: str) -> List[str]:
@@ -526,7 +526,7 @@ class CassiopeiaTree:
 
     def __remove_node(self, node) -> None:
         """Private method to remove node from tree.
-        
+
         Args:
             node: A node in the tree to be removed
 
@@ -536,27 +536,27 @@ class CassiopeiaTree:
         self.__check_network_initialized()
 
         self.__network.remove_node(node)
-    
+
     def __add_node(self, node) -> None:
         """Private method to add node to tree.
-        
+
         Args:
             node: A node to be added to the tree.
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
         self.__check_network_initialized()
-        
+
         self.__network.add_node(node)
 
     def __remove_edge(self, u, v) -> None:
         """Private method to remove edge from tree.
-        
+
         Args:
             u: The source node of the directed edge to be removed
             v: The sink node of the directed edge to be removed
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
@@ -570,7 +570,7 @@ class CassiopeiaTree:
         Args:
             u: The source node of the directed edge to be added
             v: The sink node of the directed edge to be added
-            
+
         Raises:
             CassiopeiaTreeError if the tree is not initialized.
         """
@@ -735,12 +735,12 @@ class CassiopeiaTree:
         Adjusts the branch length of specified parent-child relationships.
         This procedure maintains the consistency with the rest of the times in
         the tree. Namely, by changing branch lengths here, it will change
-        the times of all the nodes in the tree such that the times are 
+        the times of all the nodes in the tree such that the times are
         representative of the new branch lengths.
 
         Args:
             branch_dict: A dictionary of edges to updated branch lengths
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -836,7 +836,7 @@ class CassiopeiaTree:
 
         Args:
             node: Node in the tree
-            
+
         Returns:
             The list of nodes along the path from the root to the node.
         """
@@ -845,7 +845,7 @@ class CassiopeiaTree:
 
         if "ancestors" not in self.__cache:
             self.__cache["ancestors"] = {}
-        
+
         if node not in self.__cache["ancestors"]:
             self.__cache["ancestors"][node] = [n
                 for n in nx.ancestors(self.__network, node)
@@ -897,7 +897,7 @@ class CassiopeiaTree:
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
-    
+
         self.__check_network_initialized()
 
         if source is None:
@@ -930,13 +930,13 @@ class CassiopeiaTree:
                     for child in self.children(n):
                         leaves += self.leaves_in_subtree(child)
                     self.__cache["subtree"][n] = leaves
-    
+
         return self.__cache["subtree"][node]
-            
+
 
     def get_newick(self, record_branch_lengths = False) -> str:
         """Returns newick format of tree.
-        
+
         Args:
             record_branch_lengths: Whether to record branch lengths on the tree
             in the newick string
@@ -953,7 +953,7 @@ class CassiopeiaTree:
 
     def get_tree_topology(self) -> nx.DiGraph:
         """Returns the tree in Networkx format.
-        
+
         Raises:
             CassiopeiaTreeError if the tree has not been initialized.
         """
@@ -1052,7 +1052,7 @@ class CassiopeiaTree:
 
         Removes a leaf and all ancestors of that leaf that are no longer the
         ancestor of any leaves. In the context of a phylogeny, this prunes the
-        lineage of all nodes no longer relevant to observed samples. 
+        lineage of all nodes no longer relevant to observed samples.
         Additionally, maintains consistency with information on the tree by
         removing the node from the character matrix and cell metadata.
 
@@ -1113,7 +1113,7 @@ class CassiopeiaTree:
         if source is None:
             source = self.root
 
-        for node in self.depth_first_traverse_nodes(postorder = True, source = source):
+        for node in list(self.depth_first_traverse_nodes(postorder = True, source = source)):
             if self.is_leaf(node):
                 continue
             elif node == source:
@@ -1147,16 +1147,16 @@ class CassiopeiaTree:
         """Collapses mutationless edges in the tree in-place.
 
         Uses the internal node annotations of a tree to collapse edges with no
-        mutations. The introduction of a missing data event is considered a 
+        mutations. The introduction of a missing data event is considered a
         mutation in this context. Either takes the existing character states on
-        the tree or infers the annotations bottom-up from the samples obeying 
+        the tree or infers the annotations bottom-up from the samples obeying
         Camin-Sokal Parsimony. Preserves the times of nodes that are not removed
-        by connecting the parent and children of removed nodes by branchs with 
+        by connecting the parent and children of removed nodes by branchs with
         lengths equal to the total time elapsed from parent to each child.
 
         Args:
             tree: A networkx DiGraph object representing the tree
-            infer_ancestral_characters: Infer the ancestral characters states 
+            infer_ancestral_characters: Infer the ancestral characters states
                 of the tree
 
         Raises:
@@ -1165,7 +1165,7 @@ class CassiopeiaTree:
         if infer_ancestral_characters:
             self.reconstruct_ancestral_characters()
 
-        for n in self.depth_first_traverse_nodes(postorder = True):
+        for n in list(self.depth_first_traverse_nodes(postorder = True)):
             if self.is_leaf(n):
                 continue
             for child in self.children(n):
@@ -1276,7 +1276,7 @@ class CassiopeiaTree:
 
     def set_attribute(self, node: str, attribute_name: str, value: Any) -> None:
         """Sets an attribute in the tree.
-        
+
         Args:
             node: Node name
             attribute_name: Name for the new attribute
@@ -1291,11 +1291,11 @@ class CassiopeiaTree:
 
     def get_attribute(self, node: str, attribute_name: str) -> Any:
         """Retrieves the value of an attribute for a node.
-        
+
         Args:
             node: Node name
             attribute_name: Name of the attribute.
-        
+
         Returns:
             The value of the attribute for that node.
         Raises:
@@ -1306,7 +1306,7 @@ class CassiopeiaTree:
         try:
             return self.__network.nodes[node][attribute_name]
         except KeyError:
-            raise CassiopeiaTreeError(f"Attribute {attribute_name} not " 
+            raise CassiopeiaTreeError(f"Attribute {attribute_name} not "
                                     "detected for this node.")
 
     def filter_nodes(self, condition: Callable[[str], bool]) -> List[str]:

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -122,7 +122,12 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
                 _dissimilarity_map.index[j],
             )
 
-            new_node_name = str(len(tree.nodes))
+            # Use the number of nodes in the tree as the new node name.
+            # Note that initially the nodes in the tree are taken from the
+            # dissimilarity matrix, which only defines leaf nodes. Therefore,
+            # just using the number of nodes as the node name causes collisions.
+            # We prefix the name with an underscore to prevent this from happening.
+            new_node_name = f'_{len(tree.nodes)}'
             tree.add_node(new_node_name)
             tree.add_edges_from(
                 [(new_node_name, node_i), (new_node_name, node_j)]

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -100,10 +100,6 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
 
         N = dissimilarity_map.shape[0]
 
-        identifier_to_sample = dict(
-            zip([str(i) for i in range(N)], dissimilarity_map.index)
-        )
-
         # instantiate a dissimilarity map that can be updated as we join
         # together nodes.
         _dissimilarity_map = dissimilarity_map.copy()
@@ -144,8 +140,6 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
             cassiopeia_tree.root_sample_name,
             _dissimilarity_map.index.values,
         )
-
-        tree = nx.relabel_nodes(tree, identifier_to_sample)
 
         cassiopeia_tree.populate_tree(tree)
 

--- a/cassiopeia/solver/NeighborJoiningSolver.py
+++ b/cassiopeia/solver/NeighborJoiningSolver.py
@@ -163,8 +163,8 @@ class NeighborJoiningSolver(DistanceSolver.DistanceSolver):
         """
 
         i, j = (
-            np.where(dissimilarity_map.index == cherry[0])[0][0],
-            np.where(dissimilarity_map.index == cherry[1])[0][0],
+            dissimilarity_map.index.get_loc(cherry[0]),
+            dissimilarity_map.index.get_loc(cherry[1]),
         )
 
         dissimilarity_array = self.__update_dissimilarity_map_numba(
@@ -208,10 +208,8 @@ class NeighborJoiningSolver(DistanceSolver.DistanceSolver):
         # add new row & column for incoming sample
         N = dissimilarity_map.shape[1]
 
-        new_row = np.array([0.0] * N)
-        updated_map = np.vstack((dissimilarity_map, np.atleast_2d(new_row)))
-        new_col = np.array([0.0] * (N + 1))
-        updated_map = np.hstack((updated_map, np.atleast_2d(new_col).T))
+        updated_map = np.zeros((N+1, N+1))
+        updated_map[:N,:N] = dissimilarity_map
 
         new_node_index = updated_map.shape[0] - 1
         for v in range(dissimilarity_map.shape[0]):

--- a/cassiopeia/solver/UPGMASolver.py
+++ b/cassiopeia/solver/UPGMASolver.py
@@ -1,6 +1,6 @@
 """
 This file stores a subclass of DistanceSolver, UPGMA. The inference procedure is
-a hierarchical clustering algorithm proposed by Sokal and Michener (1958) that 
+a hierarchical clustering algorithm proposed by Sokal and Michener (1958) that
 iteratively joins together samples with the minimum dissimilarity.
 """
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -150,8 +150,8 @@ class UPGMASolver(DistanceSolver.DistanceSolver):
         self.__cluster_to_cluster_size[new_node] = i_size + j_size
 
         i, j = (
-            np.where(dissimilarity_map.index == cherry[0])[0][0],
-            np.where(dissimilarity_map.index == cherry[1])[0][0],
+            dissimilarity_map.index.get_loc(cherry[0]),
+            dissimilarity_map.index.get_loc(cherry[1]),
         )
 
         dissimilarity_array = self.__update_dissimilarity_map_numba(
@@ -195,14 +195,11 @@ class UPGMASolver(DistanceSolver.DistanceSolver):
             An updated dissimilarity map
 
         """
-
         # add new row & column for incoming sample
         N = dissimilarity_map.shape[1]
 
-        new_row = np.array([0.0] * N)
-        updated_map = np.vstack((dissimilarity_map, np.atleast_2d(new_row)))
-        new_col = np.array([0.0] * (N + 1))
-        updated_map = np.hstack((updated_map, np.atleast_2d(new_col).T))
+        updated_map = np.zeros((N+1, N+1))
+        updated_map[:N,:N] = dissimilarity_map
 
         new_node_index = updated_map.shape[0] - 1
         for v in range(dissimilarity_map.shape[0]):
@@ -212,8 +209,6 @@ class UPGMASolver(DistanceSolver.DistanceSolver):
                 size_i * dissimilarity_map[v, cherry_i]
                 + size_j * dissimilarity_map[v, cherry_j]
             ) / (size_i + size_j)
-
-        updated_map[new_node_index, new_node_index] = 0
 
         return updated_map
 

--- a/test/solver_tests/distance_solver_test.py
+++ b/test/solver_tests/distance_solver_test.py
@@ -1,0 +1,79 @@
+"""
+Test DistanceSolver in Cassiopeia.solver.
+"""
+import os
+import unittest
+from typing import Dict, Optional
+from unittest import mock
+
+import itertools
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+from cassiopeia.data.CassiopeiaTree import CassiopeiaTree
+from cassiopeia.solver.DistanceSolver import DistanceSolver
+from cassiopeia.solver import dissimilarity_functions
+
+class DistanceSolverMock(DistanceSolver):
+    def root_tree(self, *args, **kwargs): pass
+
+    def find_cherry(self, *args, **kwargs): pass
+
+    def update_dissimilarity_map(self, *args, **kwargs): pass
+
+    def setup_root_finder(self, *args, **kwargs): pass
+
+
+class TestDistanceSolver(unittest.TestCase):
+    def setUp(self):
+
+        cm = pd.DataFrame.from_dict(
+            {
+                "1": [0, 1, 2],
+                "2": [1, 1, 2],
+                "3": [2, 2, 2],
+                "4": [1, 1, 1],
+                "5": [0, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        delta = pd.DataFrame.from_dict(
+            {
+                "1": [0, 17, 21, 31, 23],
+                "2": [17, 0, 30, 34, 21],
+                "3": [21, 30, 0, 28, 39],
+                "4": [31, 34, 28, 0, 43],
+                "5": [23, 21, 39, 43, 0],
+            },
+            orient="index",
+            columns=["1", "2", "3", "4", "5"],
+        )
+
+        self.basic_dissimilarity_map = delta
+        self.basic_tree = CassiopeiaTree(
+            character_matrix=cm, dissimilarity_map=delta
+        )
+
+        self.distance_solver = DistanceSolverMock()
+        self.distance_solver.root_tree = mock.MagicMock()
+        self.distance_solver.find_cherry = mock.MagicMock()
+        self.distance_solver.update_dissimilarity_map = mock.MagicMock()
+        self.distance_solver.setup_root_finder = mock.MagicMock()
+
+    def test_solve_doesnt_add_duplicate_node(self):
+        self.basic_tree.root_sample_name = 'root'
+        self.distance_solver.find_cherry.return_value = (0, 1)
+        # Return dummy dissimilarity map with first dim = 2 to break the while loop.
+        self.distance_solver.update_dissimilarity_map.return_value = self.basic_dissimilarity_map.iloc[[0, 1]]
+        self.basic_tree.populate_tree = mock.MagicMock()
+        self.distance_solver.solve(self.basic_tree)
+        new_node_name = self.distance_solver.update_dissimilarity_map.call_args.args[2]
+        self.assertNotIn(
+            new_node_name, list(self.basic_tree.get_dissimilarity_map().index)
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/solver_tests/distance_solver_test.py
+++ b/test/solver_tests/distance_solver_test.py
@@ -1,19 +1,15 @@
 """
 Test DistanceSolver in Cassiopeia.solver.
 """
-import os
 import unittest
-from typing import Dict, Optional
 from unittest import mock
 
-import itertools
 import networkx as nx
-import numpy as np
 import pandas as pd
 
 from cassiopeia.data.CassiopeiaTree import CassiopeiaTree
 from cassiopeia.solver.DistanceSolver import DistanceSolver
-from cassiopeia.solver import dissimilarity_functions
+
 
 class DistanceSolverMock(DistanceSolver):
     def root_tree(self, *args, **kwargs): pass
@@ -74,6 +70,7 @@ class TestDistanceSolver(unittest.TestCase):
         self.assertNotIn(
             new_node_name, list(self.basic_tree.get_dissimilarity_map().index)
         )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I noticed the `solve` method of `DistanceSolver` was using the number of nodes in the current tree as the name of the new node that will be added (the node that connects the two cherries). Initially, the tree is initialized from the nodes in the dissimilarity matrix, which only defines the leaf nodes. The leaf node names in this matrix are not ordered. For example, the following leaves may be present in the dissimilarity matrix: `1`, `3`, `30`, `4`. These nodes are then added into the initial tree. Then, using the number of nodes in the tree (which is 4) as the name of the new node will cause problems. Namely, new edges will be added with leaf `4` as one vertex, instead of a new parent node. Also, this causes duplicate entries in the dissimilarity matrix. This PR updates the new node naming scheme to prefix all new nodes with an underscore to prevent such collisions.

Also, slight improvements to `UPGMASolver` and `NeighborJoiningSolver` and an update in `CassiopeiaTree.collapse_unifurcations` so that the iterator doesn't change during iteration.