### PR TITLE
intbc correction to whitelist in preprocessing pipeline

### DIFF
--- a/cassiopeia/preprocess/__init__.py
+++ b/cassiopeia/preprocess/__init__.py
@@ -6,6 +6,7 @@ from .pipeline import (
     align_sequences,
     call_alleles,
     collapse_umis,
+    error_correct_intbcs,
     error_correct_umis,
     resolve_umi_sequence,
     filter_molecule_table,

--- a/cassiopeia/preprocess/cassiopeia_preprocess.py
+++ b/cassiopeia/preprocess/cassiopeia_preprocess.py
@@ -26,6 +26,7 @@ STAGES = {
     "resolve": pipeline.resolve_umi_sequence,
     "align": pipeline.align_sequences,
     "call_alleles": pipeline.call_alleles,
+    "error_correct_intbcs": pipeline.error_correct_intbcs,
     "error_correct_umis": pipeline.error_correct_umis,
     "filter_molecule_table": pipeline.filter_molecule_table,
     "call_lineages": pipeline.call_lineage_groups,
@@ -85,6 +86,16 @@ def main():
         ):
             logging.warning(
                 "Skipping barcode error correction because no whitelist was "
+                "provided in the configuration."
+            )
+            continue
+        # Skip intBC correction to whitelist if whitelist_fp was not provided
+        if (
+            stage == "error_correct_intbcs"
+            and not pipeline_parameters[stage]["whitelist_fp"]
+        ):
+            logging.warning(
+                "Skipping intBC error correction because no whitelist was "
                 "provided in the configuration."
             )
             continue

--- a/cassiopeia/preprocess/constants.py
+++ b/cassiopeia/preprocess/constants.py
@@ -65,6 +65,7 @@ DEFAULT_PIPELINE_PARAMETERS = {
         "context": True,
         "context_size": 5,
     },
+    "error_correct_intbcs": {"intbc_dist_thresh": 1},
     "error_correct_umis": {
         "max_umi_distance": 2,
         "verbose": False,

--- a/cassiopeia/preprocess/pipeline.py
+++ b/cassiopeia/preprocess/pipeline.py
@@ -568,6 +568,57 @@ def call_alleles(
     return alignments
 
 
+def error_correct_intbcs(
+    input_df: pd.DataFrame,
+    whitelist_fp: str,
+    intbc_dist_thresh: int = 1,
+) -> pd.DataFrame:
+    """Corrects all intBCs to the provided whitelist.
+
+    Args:
+        input_df: Input DataFrame of alignments.
+        whitelist_fp: Path to plaintext file containing intBC whitelist.
+        intbc_dist_thresh: The threshold specifying the maximum Levenshtein
+            distance between the read sequence and whitelist to be corrected.
+
+    Returns:
+        A DataFrame of error corrected intBCs.
+    """
+    t0 = time.time()
+
+    logging.info("Beginning correcting intBCs to whitelist...")
+
+    with open(whitelist_fp, "r") as f:
+        whitelist_set = set(line.strip() for line in f if not line.isspace())
+    whitelist = list(whitelist_set)
+    unique_intbcs = list(input_df["intBC"].unique())
+    corrections = {intbc: intbc for intbc in whitelist_set}
+
+    for intbc in progress(unique_intbcs, desc="Correcting intBCs to whitelist"):
+        min_distance = np.inf
+        min_wls = []
+        if intbc not in whitelist_set:
+            for wl_intbc in whitelist:
+                distance = ngs.sequence.levenshtein_distance(intbc, wl_intbc)
+                if distance < min_distance:
+                    min_distance = distance
+                    min_wls = [wl_intbc]
+                elif distance == min_distance:
+                    min_wls.append(wl_intbc)
+
+        # Correct only if there is one matching whitelist. Discard if there
+        # are multiple possible corrections.
+        if len(min_wls) == 1 and min_distance <= intbc_dist_thresh:
+            corrections[intbc] = min_wls[0]
+
+    input_df["intBC"] = input_df["intBC"].map(corrections)
+
+    final_time = time.time()
+    logging.info(f"Finished correcting intBCs in {final_time - t0}s")
+
+    return input_df[~input_df["intBC"].isna()]
+
+
 def error_correct_umis(
     input_df: pd.DataFrame,
     max_umi_distance: int = 2,

--- a/data/preprocess.cfg
+++ b/data/preprocess.cfg
@@ -35,6 +35,10 @@ cutsite_width = 12
 context = True
 context_size = 5
 
+[error_correct_intbcs]
+whitelist_fp = "/mnt/e/scratch/cassiopeia/pipeline_test/intbc_whitelist.txt"
+intbc_dist_thresh = 1
+
 [error_correct_umis]
 max_umi_distance = 2
 verbose = False

--- a/test/preprocess_tests/config_parser_test.py
+++ b/test/preprocess_tests/config_parser_test.py
@@ -114,6 +114,7 @@ class TestCollapseUMIs(unittest.TestCase):
             "resolve",
             "align",
             "call_alleles",
+            "error_correct_intbcs",
             "error_correct_umis",
             "filter_molecule_table",
             "call_lineages",
@@ -137,6 +138,7 @@ class TestCollapseUMIs(unittest.TestCase):
         expected_procedures = [
             "align",
             "call_alleles",
+            "error_correct_intbcs",
             "error_correct_umis",
             "filter_molecule_table",
         ]

--- a/test/preprocess_tests/error_correct_intbcs_test.py
+++ b/test/preprocess_tests/error_correct_intbcs_test.py
@@ -1,0 +1,129 @@
+import os
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import cassiopeia
+
+
+class TestErrorCorrectIntBCs(unittest.TestCase):
+    def setUp(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        test_files_path = os.path.join(dir_path, "test_files")
+        self.whitelist_fp = os.path.join(test_files_path, "intbc_whitelist.txt")
+
+        self.multi_case = pd.DataFrame.from_dict(
+            {
+                "cellBC": [
+                    "A",
+                    "A",
+                    "A",
+                    "B",
+                    "B",
+                    "C",
+                    "C",
+                    "C",
+                    "C",
+                    "D",
+                    "D",
+                ],
+                "UMI": [
+                    "AACCT",
+                    "AACCG",
+                    "AACCC",
+                    "AACCT",
+                    "AACCG",
+                    "AACCT",
+                    "AACCG",
+                    "AAGGA",
+                    "AACCT",
+                    "AACCT",
+                    "AAGGG",
+                ],
+                "readCount": [20, 30, 30, 40, 50, 10, 10, 15, 10, 10, 10],
+                "Seq": [
+                    "AACCTTGG",
+                    "AACCTTGG",
+                    "AACCTTCC",
+                    "AACCTTGG",
+                    "AACCTTGC",
+                    "AACCTTCC",
+                    "AACCTTCG",
+                    "AACCTCAG",
+                    "AACCTTGG",
+                    "AACCTTGG",
+                    "AACCTAAA",
+                ],
+                "intBC": [
+                    "ACTT",
+                    "AAGG",
+                    "ACTA",
+                    "AAGN",
+                    "TACT",
+                    "TAAG",
+                    "TNNG",
+                    "ANNN",
+                    "GCTT",
+                    "NNNN",
+                    "AAAA",
+                ],
+                "r1": ["1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1"],
+                "r2": ["2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2"],
+                "r3": ["3", "3", "3", "3", "3", "3", "3", "3", "3", "3", "3"],
+                "AlignmentScore": [
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                    "20",
+                ],
+                "CIGAR": [
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                    "NA",
+                ],
+            }
+        )
+        self.multi_case["readName"] = self.multi_case.apply(
+            lambda x: "_".join([x.cellBC, x.UMI, str(x.readCount)]), axis=1
+        )
+
+        self.multi_case["allele"] = self.multi_case.apply(
+            lambda x: "_".join([x.r1, x.r2, x.r3]), axis=1
+        )
+        self.corrections = {
+            "ACTT": "ACTT",
+            "TAAG": "TAAG",
+            "ACTA": "ACTT",
+            "TNNG": "TAAG",
+            "ANNN": "ACTT"
+        }
+
+    def test_correct(self):
+
+        df = cassiopeia.pp.error_correct_intbcs(
+            self.multi_case, self.whitelist_fp, intbc_dist_thresh=1
+        )
+        expected_df = self.multi_case.copy()
+        expected_df["intBC"] = expected_df["intBC"].map(self.corrections)
+        expected_df.dropna(subset=["intBC"], inplace=True)
+
+        pd.testing.assert_frame_equal(df, expected_df)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/preprocess_tests/test_files/intbc_whitelist.txt
+++ b/test/preprocess_tests/test_files/intbc_whitelist.txt
@@ -1,0 +1,2 @@
+ACTT
+TAAG


### PR DESCRIPTION
This PR implements intBC correction to a whitelist.
It uses Levenshtein distance, as implemented in `ngs_tools`, instead of the `Levenshtein` library. This is so that ambiguous bases are treated appropriately. For instance, the `Levenshtein` library has no notion of ambiguous bases, so `ATCN` and `ATCC` has distance of 1. However, the implementation in `ngs_tools` treats `N` and `C` as identical, so distance is 0.