### PR TITLE
Minor changes to preprocessing utilities

### DIFF
--- a/cassiopeia/preprocess/lineage_utils.py
+++ b/cassiopeia/preprocess/lineage_utils.py
@@ -388,8 +388,10 @@ def filtered_lineage_group_to_allele_table(
     Returns:
         final_df: A final processed DataFrame with indel information
     """
-
     final_df = pd.concat(filtered_lgs, sort=True)
+
+    if "lineageGrp" not in final_df.columns:
+        final_df['lineageGrp'] = 1
 
     grouping = []
     for i in final_df.columns:
@@ -401,11 +403,8 @@ def filtered_lineage_group_to_allele_table(
         {"UMI": "count", "readCount": "sum"}
     )
 
-    final_df["Sample"] = final_df.apply(
-        lambda x: x.cellBC.split(".")[0], axis=1
-    )
-
     return final_df
+
 
 
 def plot_overlap_heatmap(at, at_pivot_I, output_directory):

--- a/cassiopeia/preprocess/lineage_utils.py
+++ b/cassiopeia/preprocess/lineage_utils.py
@@ -391,7 +391,7 @@ def filtered_lineage_group_to_allele_table(
     final_df = pd.concat(filtered_lgs, sort=True)
 
     if "lineageGrp" not in final_df.columns:
-        final_df['lineageGrp'] = 1
+        final_df["lineageGrp"] = 1
 
     grouping = []
     for i in final_df.columns:
@@ -404,7 +404,6 @@ def filtered_lineage_group_to_allele_table(
     )
 
     return final_df
-
 
 
 def plot_overlap_heatmap(at, at_pivot_I, output_directory):

--- a/cassiopeia/preprocess/pipeline.py
+++ b/cassiopeia/preprocess/pipeline.py
@@ -3,6 +3,7 @@ This file contains all high-level functionality for preprocessing sequencing
 data into character matrices ready for phylogenetic inference. This file
 is mainly invoked by cassiopeia_preprocess.py.
 """
+import warnings
 
 from functools import partial
 import os
@@ -21,6 +22,7 @@ from tqdm.auto import tqdm
 from typing_extensions import Literal
 
 from cassiopeia.mixins import logger, PreprocessError
+from cassiopeia.mixins.warnings import PreprocessWarning
 from cassiopeia.preprocess import (
     alignment_utilities,
     constants,
@@ -634,6 +636,17 @@ def call_alleles(
     alignments = alignments.join(indel_df)
 
     alignments.reset_index(inplace=True)
+
+    # check cut-sites and raise a warning if any missing data is detected
+    cutsites = utilities.get_default_cut_site_columns(alignments)
+    if np.any((alignments[cutsites] == "").sum(axis=0) > 0):
+        warnings.warn(
+                "Detected missing data in alleles. You might"
+                " consider re-running align_sequences with a"
+                " lower gap-open penalty, or using a separate"
+                " alignment strategy.",
+                PreprocessWarning,
+            )
 
     return alignments
 

--- a/cassiopeia/preprocess/pipeline.py
+++ b/cassiopeia/preprocess/pipeline.py
@@ -489,8 +489,10 @@ def align_sequences(
     try:
         from skbio import alignment
     except ModuleNotFoundError:
-        raise PreprocessError("Scikit-bio is not installed. Try pip-installing "
-                            " first and then re-running this function.")
+        raise PreprocessError(
+            "Scikit-bio is not installed. Try pip-installing "
+            " first and then re-running this function."
+        )
 
     if (ref is None) == (ref_filepath is None):
         raise PreprocessError(
@@ -641,12 +643,12 @@ def call_alleles(
     cutsites = utilities.get_default_cut_site_columns(alignments)
     if np.any((alignments[cutsites] == "").sum(axis=0) > 0):
         warnings.warn(
-                "Detected missing data in alleles. You might"
-                " consider re-running align_sequences with a"
-                " lower gap-open penalty, or using a separate"
-                " alignment strategy.",
-                PreprocessWarning,
-            )
+            "Detected missing data in alleles. You might"
+            " consider re-running align_sequences with a"
+            " lower gap-open penalty, or using a separate"
+            " alignment strategy.",
+            PreprocessWarning,
+        )
 
     return alignments
 

--- a/cassiopeia/preprocess/utilities.py
+++ b/cassiopeia/preprocess/utilities.py
@@ -659,7 +659,9 @@ def convert_lineage_profile_to_character_matrix(
 
     lineage_profile = lineage_profile.fillna("Missing").copy()
     if missing_allele_indicator:
-        lineage_profile.replace({missing_allele_indicator: "Missing"}, inplace=True)
+        lineage_profile.replace(
+            {missing_allele_indicator: "Missing"}, inplace=True
+        )
 
     samples = []
 

--- a/cassiopeia/preprocess/utilities.py
+++ b/cassiopeia/preprocess/utilities.py
@@ -407,7 +407,7 @@ def convert_alleletable_to_character_matrix(
             allele represented by this proportion
         missing_data_allele: Value in the allele table that indicates that the
             cut-site is missing. This will be converted into 
-            :param:`missing_data_state` 
+            ``missing_data_state`` 
         missing_data_state: A state to use for missing data.
         mutation_priors: A table storing the prior probability of a mutation
             occurring. This table is used to create a character matrix-specific
@@ -420,8 +420,8 @@ def convert_alleletable_to_character_matrix(
             effect if there are no allele conflicts. Defaults to True.
 
         Returns:
-        A character matrix, a probability dictionary, and a dictionary mapping
-            states to the original mutation.
+            A character matrix, a probability dictionary, and a dictionary mapping
+                states to the original mutation.
     """
     if cut_sites is None:
         cut_sites = get_default_cut_site_columns(alleletable)

--- a/cassiopeia/preprocess/utilities.py
+++ b/cassiopeia/preprocess/utilities.py
@@ -384,6 +384,7 @@ def convert_alleletable_to_character_matrix(
     alleletable: pd.DataFrame,
     ignore_intbcs: List[str] = [],
     allele_rep_thresh: float = 1.0,
+    missing_data_allele: Optional[str] = None,
     missing_data_state: int = -1,
     mutation_priors: Optional[pd.DataFrame] = None,
     cut_sites: Optional[List[str]] = None,
@@ -404,6 +405,9 @@ def convert_alleletable_to_character_matrix(
         ignore_intbcs: A set of intBCs to ignore
         allele_rep_thresh: A threshold for removing target sites that have an
             allele represented by this proportion
+        missing_data_allele: Value in the allele table that indicates that the
+            cut-site is missing. This will be converted into 
+            :param:`missing_data_state` 
         missing_data_state: A state to use for missing data.
         mutation_priors: A table storing the prior probability of a mutation
             occurring. This table is used to create a character matrix-specific
@@ -489,6 +493,11 @@ def convert_alleletable_to_character_matrix(
 
                     if state == "NONE" or "None" in state:
                         transformed_states.append(0)
+                    elif (
+                        missing_data_allele is not None
+                        and state == missing_data_allele
+                    ):
+                        transformed_states.append(missing_data_state)
                     else:
                         if state in allele_counter[c]:
                             transformed_states.append(allele_counter[c][state])
@@ -614,6 +623,7 @@ def convert_alleletable_to_lineage_profile(
 def convert_lineage_profile_to_character_matrix(
     lineage_profile: pd.DataFrame,
     indel_priors: Optional[pd.DataFrame] = None,
+    missing_allele_indicator: Optional[str] = None,
     missing_state_indicator: int = -1,
 ) -> Tuple[
     pd.DataFrame, Dict[int, Dict[int, float]], Dict[int, Dict[int, str]]
@@ -633,6 +643,8 @@ def convert_lineage_profile_to_character_matrix(
     Args:
         lineage_profile: Lineage profile
         indel_priors: Dataframe mapping indels to prior probabilities
+        missing_allele_indicator: An allele that is being used to represent
+            missing data.
         missing_state_indicator: State to indicate missing data
 
     Returns:
@@ -643,7 +655,11 @@ def convert_lineage_profile_to_character_matrix(
     prior_probs = defaultdict(dict)
     indel_to_charstate = defaultdict(dict)
 
+    lineage_profile = lineage_profile.copy()
+
     lineage_profile = lineage_profile.fillna("Missing").copy()
+    if missing_allele_indicator:
+        lineage_profile.replace({missing_allele_indicator: "Missing"}, inplace=True)
 
     samples = []
 

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -15,5 +15,6 @@ Small-Parsimony
 .. autosummary::
    :toctree: reference/
    
+   tl.fitch_count
    tl.fitch_hartigan
    tl.score_small_parsimony

--- a/test/preprocess_tests/call_alleles_test.py
+++ b/test/preprocess_tests/call_alleles_test.py
@@ -60,19 +60,23 @@ class TestCallAlleles(unittest.TestCase):
             lambda x: x.cellBC + "_" + x.UMI + "_" + str(x.readCount), axis=1
         )
 
-        new_row = pd.DataFrame.from_dict({
-            "cellBC": "C",
-            "UMI": "CTG",
-            "readCount": 10,
-            "CIGAR": "3M",
-            "QueryBegin": 0,
-            "ReferenceBegin": 0,
-            "AlignmentScore": 100,
-            "Seq": "ACG",
-            "readName": "C_CTG_10",
-        }, orient='index').T
-        self.alignment_dataframe_with_missing = pd.concat([self.alignment_dataframe, new_row])
-
+        new_row = pd.DataFrame.from_dict(
+            {
+                "cellBC": "C",
+                "UMI": "CTG",
+                "readCount": 10,
+                "CIGAR": "3M",
+                "QueryBegin": 0,
+                "ReferenceBegin": 0,
+                "AlignmentScore": 100,
+                "Seq": "ACG",
+                "readName": "C_CTG_10",
+            },
+            orient="index",
+        ).T
+        self.alignment_dataframe_with_missing = pd.concat(
+            [self.alignment_dataframe, new_row]
+        )
 
     def test_basic_cigar_string_match(self):
 
@@ -380,7 +384,7 @@ class TestCallAlleles(unittest.TestCase):
             self.assertEqual(row.intBC, expected_intbcs[row.readName])
 
     def test_missing_data_in_allele_throws_warning(self):
-        
+
         with self.assertWarns(PreprocessWarning):
             molecule_table = cassiopeia.pp.call_alleles(
                 self.alignment_dataframe_with_missing,

--- a/test/preprocess_tests/call_lineage_groups_test.py
+++ b/test/preprocess_tests/call_lineage_groups_test.py
@@ -334,7 +334,6 @@ class TestCallLineageGroup(unittest.TestCase):
             inter_doublet_threshold=0.6,
         )
 
-
         expected_rows = {
             ("A", "XX"): (1, 2),
             ("B", "XX"): (1, 2),
@@ -450,10 +449,12 @@ class TestCallLineageGroup(unittest.TestCase):
 
     def test_filter_lineage_group_to_allele_table_single_lineage(self):
 
-        aln_df = lineage_utils.filtered_lineage_group_to_allele_table([self.basic_grouping])
+        aln_df = lineage_utils.filtered_lineage_group_to_allele_table(
+            [self.basic_grouping]
+        )
 
         self.assertIn("lineageGrp", aln_df)
-        
+
         expected_rows = {
             ("A", "XX"): (1, 3),
             ("B", "XX"): (1, 1),
@@ -481,6 +482,7 @@ class TestCallLineageGroup(unittest.TestCase):
                 ].iloc[0],
                 expected_lineage[1],
             )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/preprocess_tests/call_lineage_groups_test.py
+++ b/test/preprocess_tests/call_lineage_groups_test.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pathlib as Path
 
 import cassiopeia
-from cassiopeia.preprocess import pipeline
+from cassiopeia.preprocess import pipeline, lineage_utils
 
 
 class TestCallLineageGroup(unittest.TestCase):
@@ -334,9 +334,6 @@ class TestCallLineageGroup(unittest.TestCase):
             inter_doublet_threshold=0.6,
         )
 
-        samples = aln_df["Sample"]
-        self.assertNotIn("C", samples)
-        self.assertNotIn("F", samples)
 
         expected_rows = {
             ("A", "XX"): (1, 2),
@@ -451,6 +448,39 @@ class TestCallLineageGroup(unittest.TestCase):
                 expected_lineage[1],
             )
 
+    def test_filter_lineage_group_to_allele_table_single_lineage(self):
+
+        aln_df = lineage_utils.filtered_lineage_group_to_allele_table([self.basic_grouping])
+
+        self.assertIn("lineageGrp", aln_df)
+        
+        expected_rows = {
+            ("A", "XX"): (1, 3),
+            ("B", "XX"): (1, 1),
+            ("C", "XZ"): (1, 1),
+        }
+
+        for pair in expected_rows:
+
+            expected_lineage = expected_rows[pair]
+
+            self.assertEqual(
+                aln_df.loc[
+                    (aln_df["cellBC"] == pair[0])
+                    & (aln_df["intBC"] == pair[1]),
+                    "lineageGrp",
+                ].iloc[0],
+                expected_lineage[0],
+            )
+
+            self.assertEqual(
+                aln_df.loc[
+                    (aln_df["cellBC"] == pair[0])
+                    & (aln_df["intBC"] == pair[1]),
+                    "UMI",
+                ].iloc[0],
+                expected_lineage[1],
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/preprocess_tests/character_matrix_test.py
+++ b/test/preprocess_tests/character_matrix_test.py
@@ -100,7 +100,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         pd.testing.assert_frame_equal(character_matrix, expected_df)
 
     def test_character_matrix_formation_custom_missing_data(self):
-        
+
         self.alleletable_basic.loc[0, "r1"] = "missing"
 
         (
@@ -108,7 +108,9 @@ class TestCharacterMatrixFormation(unittest.TestCase):
             priors,
             indel_states,
         ) = cas.pp.convert_alleletable_to_character_matrix(
-            self.alleletable_basic, missing_data_allele="missing", missing_data_state=-3
+            self.alleletable_basic,
+            missing_data_allele="missing",
+            missing_data_state=-3,
         )
 
         self.assertEqual(character_matrix.shape[0], 3)
@@ -872,7 +874,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
 
         self.alleletable_basic.fillna("MISSING", inplace=True)
         lineage_profile = cas.pp.convert_alleletable_to_lineage_profile(
-            self.alleletable_basic,
+            self.alleletable_basic
         )
 
         (
@@ -880,7 +882,9 @@ class TestCharacterMatrixFormation(unittest.TestCase):
             priors,
             state_to_indel,
         ) = cas.pp.convert_lineage_profile_to_character_matrix(
-            lineage_profile, self.mutation_priors, missing_allele_indicator="MISSING",
+            lineage_profile,
+            self.mutation_priors,
+            missing_allele_indicator="MISSING",
         )
 
         self.assertEqual(len(priors), 7)


### PR DESCRIPTION
This PR addresses some issues that we identified in the preprocessing pipeline, especially related to using GESTALT data. These are miscellaneous and include:

* Raising a warning if there is missing data detected in the alleles after `cas.pp.call_alleles`. This likely stems from the alignment strategy not being ideal for GESALT data (see #127).
* Enabling missing data to be specified when converting to character matrices. This allows users to let these functions know how missing data is encoded as an allele and the changes to the utilities will not automatically convert these to `missing_state_indicator`.
* Flexibility to pass in a single lineage group into `cas.pp.lineage_utils.filtered_lineage_group_to_allele_table`.
