### PR TITLE
ILPSolverError when Potential Graph cannot be inferred

### DIFF
--- a/cassiopeia/solver/ILPSolver.py
+++ b/cassiopeia/solver/ILPSolver.py
@@ -213,6 +213,12 @@ class ILPSolver(CassiopeiaSolver.CassiopeiaSolver):
             cassiopeia_tree.missing_state_indicator,
         )
 
+        if len(potential_graph.edges()) == 0:
+            raise ILPSolverError("Potential Graph could not be found with" 
+                                " solver parameters. Try increasing"
+                                " `maximum_potential_graph_layer_size` or"
+                                " using another solver.")
+
         # generate Steiner Tree ILP model
         nodes = list(potential_graph.nodes())
         encoder = dict(zip(nodes, list(range(len(nodes)))))

--- a/cassiopeia/solver/ILPSolver.py
+++ b/cassiopeia/solver/ILPSolver.py
@@ -213,12 +213,6 @@ class ILPSolver(CassiopeiaSolver.CassiopeiaSolver):
             cassiopeia_tree.missing_state_indicator,
         )
 
-        if len(potential_graph.edges()) == 0:
-            raise ILPSolverError("Potential Graph could not be found with" 
-                                " solver parameters. Try increasing"
-                                " `maximum_potential_graph_layer_size` or"
-                                " using another solver.")
-
         # generate Steiner Tree ILP model
         nodes = list(potential_graph.nodes())
         encoder = dict(zip(nodes, list(range(len(nodes)))))
@@ -315,6 +309,12 @@ class ILPSolver(CassiopeiaSolver.CassiopeiaSolver):
                 missing_state_indicator,
             )
         )
+
+        if len(potential_graph_edges) == 0:
+            raise ILPSolverError("Potential Graph could not be found with" 
+                                " solver parameters. Try increasing"
+                                " `maximum_potential_graph_layer_size` or"
+                                " using another solver.")
 
         # the potential graph edges returned are strings in the form
         # "state1|state2|...", so we "decode" them here

--- a/test/solver_tests/ilp_solver_test.py
+++ b/test/solver_tests/ilp_solver_test.py
@@ -103,6 +103,10 @@ class TestILPSolver(unittest.TestCase):
 
         self.ilp_solver = cas.solver.ILPSolver(mip_gap=0.0)
 
+        # for the purposes of making sure we throw an error when a potential
+        # graph cannot be solved
+        self.ilp_solver_small = cas.solver.ILPSolver(mip_gap=0.0, maximum_potential_graph_layer_size=3)
+
     def test_raises_error_on_ambiguous(self):
         cm = pd.DataFrame.from_dict(
             {
@@ -661,6 +665,11 @@ class TestILPSolver(unittest.TestCase):
             expected_triplet = find_triplet_structure(triplet, expected_tree)
             observed_triplet = find_triplet_structure(triplet, tree)
             self.assertEqual(expected_triplet, observed_triplet)
+
+    @unittest.skipUnless(GUROBI_INSTALLED, "Gurobi installation not found.")
+    def test_ilp_throws_error_when_potential_graph_is_not_found(self):
+        
+        self.ilp_solver_small.solve(self.missing_tree, logfile=self.logfile)
 
     def tearDown(self):
 

--- a/test/solver_tests/ilp_solver_test.py
+++ b/test/solver_tests/ilp_solver_test.py
@@ -669,7 +669,8 @@ class TestILPSolver(unittest.TestCase):
     @unittest.skipUnless(GUROBI_INSTALLED, "Gurobi installation not found.")
     def test_ilp_throws_error_when_potential_graph_is_not_found(self):
         
-        self.ilp_solver_small.solve(self.missing_tree, logfile=self.logfile)
+        with self.assertRaises(ILPSolverError):
+            self.ilp_solver_small.solve(self.missing_tree, logfile=self.logfile)
 
     def tearDown(self):
 


### PR DESCRIPTION
We want to throw an informative error when a potential graph cannot be inferred (e.g., if the maximum potential graph layer size is too small for the dataset). This PR address the issue raised recently noticing an uninformative KeyError when the potential graph cannot be inferred (#118). 