### PR TITLE
Precompute dissimilarity map row sums

### DIFF
--- a/cassiopeia/solver/NeighborJoiningSolver.py
+++ b/cassiopeia/solver/NeighborJoiningSolver.py
@@ -130,14 +130,15 @@ class NeighborJoiningSolver(DistanceSolver.DistanceSolver):
 
         q = np.zeros(dissimilarity_map.shape)
         n = dissimilarity_map.shape[0]
+        dissimilarity_map_rowsums = dissimilarity_map.sum(axis=1)
         for i in range(n):
             for j in range(i):
                 q[i, j] = q[j, i] = (dissimilarity_map[i, j]) - (
                     1
                     / (n - 2)
                     * (
-                        dissimilarity_map[i, :].sum()
-                        + dissimilarity_map[j, :].sum()
+                        dissimilarity_map_rowsums[i]
+                        + dissimilarity_map_rowsums[j]
                     )
                 )
         return q


### PR DESCRIPTION
The `compute_q` method of the `NeighborJoiningSolver` can be sped up by caching the row sums of the dissimilarity matrix.

Test plan: With the new implementation, NJ takes ~6 seconds on my computer for 1024 cells. Here is the code:
```
import time
from cassiopeia.solver import NeighborJoiningSolver
from cassiopeia.simulator import CompleteBinarySimulator, Cas9LineageTracingDataSimulator

# Simulate perfect binary tree with 1024 cells
tree = CompleteBinarySimulator(depth=10).simulate_tree()
print(f"Number of cells: {tree.n_cell}")

# Overlay lineage tracing data
lt = Cas9LineageTracingDataSimulator()
lt.overlay_data(tree)

solver = NeighborJoiningSolver(add_root = True)

# Warm-start the solver (numba overhead)
solver.solve(tree)

# Now time
st = time.time()
solver.solve(tree)
print(f"time taken for NJ: {time.time() - st}")
```

With the old implementation it already takes ~16 seconds for 512 cells. Didn't attempt 1024.