### PR TITLE
SNJ Implementation Draft 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 *.c
 stdout.log
 notebooks/.ipynb_checkpoints
+*.pdf

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -75,7 +75,6 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
         self.dissimilarity_function = dissimilarity_function
         self.add_root = add_root
 
-    # @override
     def get_dissimilarity_map(
         self, 
         cassiopeia_tree: CassiopeiaTree,

--- a/cassiopeia/solver/DistanceSolver.py
+++ b/cassiopeia/solver/DistanceSolver.py
@@ -75,6 +75,19 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
         self.dissimilarity_function = dissimilarity_function
         self.add_root = add_root
 
+    # @override
+    def get_dissimilarity_map(
+        self, 
+        cassiopeia_tree: CassiopeiaTree,
+        layer: Optional[str] = None
+    ) -> pd.DataFrame: #todo: docstring
+
+        self.setup_dissimilarity_map(cassiopeia_tree, layer)
+        dissimilarity_map = cassiopeia_tree.get_dissimilarity_map()
+
+        return dissimilarity_map
+
+
     def solve(
         self,
         cassiopeia_tree: CassiopeiaTree,
@@ -103,9 +116,7 @@ class DistanceSolver(CassiopeiaSolver.CassiopeiaSolver):
         """
         node_name_generator = solver_utilities.node_name_generator()
 
-        self.setup_dissimilarity_map(cassiopeia_tree, layer)
-
-        dissimilarity_map = cassiopeia_tree.get_dissimilarity_map()
+        dissimilarity_map = self.get_dissimilarity_map(cassiopeia_tree, layer)
 
         N = dissimilarity_map.shape[0]
 

--- a/cassiopeia/solver/SpectralNeighborJoiningSolver.py
+++ b/cassiopeia/solver/SpectralNeighborJoiningSolver.py
@@ -10,15 +10,21 @@ import numpy as np
 import pandas as pd
 from itertools import chain
 
+# Only for debugging purposes
+if True:
+    import sys
+    sys.path.insert(0, '../..')
+
+from cassiopeia.solver.DistanceSolver import DistanceSolver
+
 from cassiopeia.data import CassiopeiaTree
 from cassiopeia.solver import (
-    NeighborJoiningSolver,
     dissimilarity_functions,
     solver_utilities,
 )
 
 
-class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
+class SpectralNeighborJoiningSolver(DistanceSolver):
     """
     Spectral Neighbor-joining class for Cassiopeia.
 
@@ -40,30 +46,81 @@ class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
     ):
         super().__init__(dissimilarity_function, add_root=add_root, prior_transformation=prior_transformation) #type: ignore
 
+    def root_tree(
+        self, tree: nx.Graph, root_sample: str, remaining_samples: List[str]
+    ) -> nx.DiGraph():
+        """Roots a tree produced by Neighbor-Joining at the specified root.
 
-    def find_cherry(self, dissimilarity_matrix: np.ndarray, lambda_indices: List[List[int]] = None) -> Tuple[int, int]:
-        """Finds a pair of samples to join into a cherry.
-
-        Proceeds by minimizing the second largest SVD of the RA Matrix of some subset of nodes.
+        Uses the specified root to root the tree passed in
 
         Args:
-            dissimilarity_matrix: A sample x sample dissimilarity matrix
+            tree: Networkx object representing the tree topology
+            root_sample: Sample to treat as the root
+            remaining_samples: The last two unjoined nodes in the tree
+
+        Returns:
+            A rooted tree
+        """
+        tree.add_edge(remaining_samples[0], remaining_samples[1])
+
+        rooted_tree = nx.DiGraph()
+        for e in nx.dfs_edges(tree, source=root_sample):
+            rooted_tree.add_edge(e[0], e[1])
+
+        return rooted_tree
+
+    def get_dissimilarity_map(
+        self, 
+        cassiopeia_tree: CassiopeiaTree,
+        layer: Optional[str] = None
+    ) -> pd.DataFrame: 
+        """Outputs the first lambda matrix, where every subset is an individual node.
+
+        Args:
+            cassiopeia_tree: the CassiopeiaTree object passed into solve()
+            layer: Layer storing the character matrix for solving. If None, the
+                default character matrix is used in the CassiopeiaTree.
+
+        Returns:
+            DataFrame object of the lamba matrix, but similar in structure to DistanceSolver's dissimilarity_map.
+        """
+
+        # get similarity map and save it as private instance variable
+        self.__similarity_map = super().get_dissimilarity_map(cassiopeia_tree, layer)
+
+        # generate first (pairwise) lambda matrix
+        N = self.__similarity_map.shape[0]
+        self.lambda_indices: List[List[int]] = [[i] for i in range(N)]
+        node_names: np.ndarray = self.__similarity_map.index.values
+
+        lambda_matrix_arr = self.__compute_lambda(self.lambda_indices)
+
+        lambda_matrix_df = pd.DataFrame(
+            lambda_matrix_arr, 
+            index=node_names,
+            columns=node_names
+        )        
+
+        return lambda_matrix_df
+
+
+    def find_cherry(self, dissimilarity_map: np.ndarray) -> Tuple[int, int]:
+        """Finds a pair of samples to join into a cherry.
+
+        With dissimilarity_map being the lambda matrix, this method finds the argmin pair of subsets of the lambda matrix. 
+
+        Args:
+            dissimilarity_matrix: Lambda matrix
 
         Returns:
             A tuple of intgers representing rows in the dissimilarity matrix
                 to join.
         """
-        # temp? to pass tests
-        if not lambda_indices:
-            lambda_indices = [[i] for i in range(dissimilarity_matrix.shape[0])]
 
-        lambda_matrix = self.__compute_lambda(dissimilarity_matrix, lambda_indices)
-        np.fill_diagonal(lambda_matrix, np.inf)
-
-        return np.unravel_index(np.argmin(lambda_matrix, axis=None), lambda_matrix.shape) # TODO: cache with heapq?
+        return np.unravel_index(np.argmin(dissimilarity_map, axis=None), dissimilarity_map.shape) # type: ignore
 
 
-    def __compute_lambda(self, dissimilarity_map: np.ndarray, lambda_indices: List[List[int]]) -> np.ndarray:
+    def __compute_lambda(self, lambda_indices: List[List[int]]) -> np.ndarray:
         """Computes the lambda matrix, whose entries consist of the second SVD of the R^A affinity matrix for every pair of nodes.
 
         Computes the lambda(i,j) = SVD # 2 for R^(Ai U Aj) where i and j are the susbet indices in lambda_indices.
@@ -76,7 +133,7 @@ class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
         """
 
         n = len(lambda_indices)
-        lambda_matrix = np.zeros([n, n])
+        lambda_matrix_arr = np.zeros([n, n])
 
         for i_count, i in enumerate(lambda_indices):
             for j_count, j in enumerate(lambda_indices):
@@ -92,29 +149,43 @@ class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
                 a_comp_flat = list(chain.from_iterable(a_comp))
 
                 # create RA matrix
-                RA_matrix = dissimilarity_map[np.ix_(a_subset, a_comp_flat)]
+                RA_matrix = self.__similarity_map.values[np.ix_(a_subset, a_comp_flat)]
 
                 # Calculate SVD2
-                lambda_matrix[i_count, j_count] = lambda_matrix[j_count, i_count] = np.linalg.svd(RA_matrix)[1][1]
+                lambda_matrix_arr[i_count, j_count] = lambda_matrix_arr[j_count, i_count] = np.linalg.svd(RA_matrix)[1][1]
 
-        return lambda_matrix
+        np.fill_diagonal(lambda_matrix_arr, np.inf)
 
-    def __update_lambda_indices(
+        return lambda_matrix_arr
+
+    def update_dissimilarity_map(
         self,
-        lambda_indices: List[List[int]],
-        node_names: np.ndarray,
+        dissimilarity_map: pd.DataFrame, # lambda matrix
         cherry: Tuple[str, str],
         new_node: str,
-        ) -> Tuple[List[List[int]], np.ndarray]:
+        ) -> pd.DataFrame:
+        """Updates the lambda matrix using the pair of subsets from find_cherry.
 
-        lambda_indices_copy = lambda_indices.copy()
+        Args:
+            dissimilarity_map: lambda matrix to update
+            cherry1: One of the children to join.
+            cherry2: One of the children to join.
+            new_node: New node name to add to the dissimilarity map
 
+        Returns:
+            An updated lambda matrix.
+        """
+
+        lambda_indices_copy = self.lambda_indices.copy()
+
+        # get cherry nodes in index of lambda matrix
         i, j = (
-            np.where(node_names == cherry[0])[0][0], # type: ignore
-            np.where(node_names == cherry[1])[0][0], # type: ignore
+            np.where(dissimilarity_map.index == cherry[0])[0][0],
+            np.where(dissimilarity_map.index == cherry[1])[0][0],
         )
 
         # modify names
+        node_names = dissimilarity_map.index.values
         node_names = np.append(node_names, new_node) # type: ignore
         node_names = np.delete(node_names, [i, j])
 
@@ -123,106 +194,71 @@ class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
         lambda_indices_copy.pop(max(i, j))
         lambda_indices_copy.pop(min(i, j))
 
-        return (lambda_indices_copy, node_names)
+        if len(lambda_indices_copy) > 2:
+            # compute new lambda matrix
+            lambda_matrix_arr = self.__compute_lambda(lambda_indices_copy)
+        else:
+            n = len(lambda_indices_copy)
+            lambda_matrix_arr = np.zeros((n, n))
 
-
-    # TODO: document the change: just replace update dissimilarity map into update lambda_index matrix
-    def solve(
-        self,
-        cassiopeia_tree: CassiopeiaTree,
-        layer: Optional[str] = None,
-        collapse_mutationless_edges: bool = False,
-        logfile: str = "stdout.log",
-    ) -> None:
-        """Solves a tree for a general bottom-up distance-based solver routine.
-
-        The general solver routine proceeds by iteratively finding pairs of
-        samples to join together into a "cherry" and then reform the
-        dissimilarity matrix with respect to this new cherry. The implementation
-        of how to find cherries and update the dissimilarity map is left to
-        subclasses of DistanceSolver. The function will update the `tree`
-        attribute of the input CassiopeiaTree.
-
-        Args:
-            cassiopeia_tree: CassiopeiaTree object to be populated
-            layer: Layer storing the character matrix for solving. If None, the
-                default character matrix is used in the CassiopeiaTree.
-            collapse_mutationless_edges: Indicates if the final reconstructed
-                tree should collapse mutationless edges based on internal states
-                inferred by Camin-Sokal parsimony. In scoring accuracy, this
-                removes artifacts caused by arbitrarily resolving polytomies.
-            logfile: File location to log output. Not currently used.
-        """
-        node_name_generator = solver_utilities.node_name_generator()
-
-        self.setup_dissimilarity_map(cassiopeia_tree, layer)
-
-        dissimilarity_map = cassiopeia_tree.get_dissimilarity_map()
-
-        N = dissimilarity_map.shape[0]
-
-        # instantiate a dissimilarity map that can be updated as we join
-        # together nodes.
-        _dissimilarity_map = dissimilarity_map.copy()
-
-        # instantiate a tree where all samples appear as leaves.
-        tree = nx.Graph()
-        tree.add_nodes_from(_dissimilarity_map.index)
-
-        # Construct Lambda Indices matrix
-        lambda_indices: List[List[int]] = [[i] for i in range(N)]
-        node_names: np.ndarray = _dissimilarity_map.index.values
-
-        while N > 2:
-            print(f'# Running with N={N}')
-            i, j = self.find_cherry(_dissimilarity_map.to_numpy(), lambda_indices)
-
-            # get node names to join
-            node_i, node_j = (
-                node_names[i],
-                node_names[j],
-            ) 
-
-            new_node_name = next(node_name_generator)
-            tree.add_node(new_node_name)
-            tree.add_edges_from([
-                (new_node_name, node_i), 
-                (new_node_name, node_j)
-            ])
-
-            # Changed for SNJ
-            lambda_indices, node_names = self.__update_lambda_indices(
-                    lambda_indices, 
-                    node_names,
-                    (node_i, node_j), 
-                    new_node_name
-                )
-
-            N = len(lambda_indices)
-
-        tree = self.root_tree(
-            tree,
-            cassiopeia_tree.root_sample_name,
-            node_names,
+        # regenerate lambda matrix
+        lambda_matrix_df = pd.DataFrame(
+            lambda_matrix_arr,
+            index=node_names,
+            columns=node_names
         )
 
-        # remove root from character matrix before populating tree
-        if (
-            cassiopeia_tree.root_sample_name
-            in cassiopeia_tree.character_matrix.index
-        ):
-            cassiopeia_tree.character_matrix = (
-                cassiopeia_tree.character_matrix.drop(
-                    index=cassiopeia_tree.root_sample_name
+        # update lambda indices
+        self.lambda_indices = lambda_indices_copy
+        
+
+        return lambda_matrix_df
+
+    def setup_root_finder(self, cassiopeia_tree: CassiopeiaTree) -> None:
+        """Defines the implicit rooting strategy for the NeighborJoiningSolver.
+
+        By default, the NeighborJoining algorithm returns an unrooted tree.
+        To root this tree, an implicit root of all zeros is added to the
+        character matrix. Then, the dissimilarity map is recalculated using
+        the updated character matrix. If the tree already has a computed
+        dissimilarity map, only the new dissimilarities are calculated.
+
+        Args:
+            cassiopeia_tree: Input CassiopeiaTree to `solve`
+        """
+        character_matrix = cassiopeia_tree.character_matrix.copy()
+        rooted_character_matrix = character_matrix.copy()
+
+        root = [0] * rooted_character_matrix.shape[1]
+        rooted_character_matrix.loc["root"] = root
+        cassiopeia_tree.root_sample_name = "root"
+        cassiopeia_tree.character_matrix = rooted_character_matrix
+
+        if self.dissimilarity_function is None:
+            raise DistanceSolver.DistanceSolverError(
+                "Please specify a dissimilarity function to add an implicit "
+                "root, or specify an explicit root"
+            )
+
+        dissimilarity_map = cassiopeia_tree.get_dissimilarity_map()
+        if dissimilarity_map is None:
+            cassiopeia_tree.compute_dissimilarity_map(
+                self.dissimilarity_function, self.prior_transformation
+            )
+        else:
+            dissimilarity = {"root": 0}
+            for leaf in character_matrix.index:
+                weights = None
+                if cassiopeia_tree.priors:
+                    weights = solver_utilities.transform_priors(
+                        cassiopeia_tree.priors, self.prior_transformation
+                    )
+                dissimilarity[leaf] = self.dissimilarity_function(
+                    rooted_character_matrix.loc["root"].values,
+                    rooted_character_matrix.loc[leaf].values,
+                    cassiopeia_tree.missing_state_indicator,
+                    weights,
                 )
-            )
+            cassiopeia_tree.set_dissimilarity("root", dissimilarity)
 
-        cassiopeia_tree.populate_tree(tree, layer=layer)
-        cassiopeia_tree.collapse_unifurcations()
-
-        # collapse mutationless edges
-        if collapse_mutationless_edges:
-            cassiopeia_tree.collapse_mutationless_edges(
-                infer_ancestral_characters=True
-            )
-
+        cassiopeia_tree.character_matrix = character_matrix

--- a/cassiopeia/solver/SpectralNeighborJoiningSolver.py
+++ b/cassiopeia/solver/SpectralNeighborJoiningSolver.py
@@ -135,28 +135,12 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
                     ]
 
                 # Calculate SVD2 #todo: remove alternatives
-                svd_mode = 3
-
                 svd2_val = 0
-                if svd_mode == 0:
-                    svd2_val = np.linalg.svd(RA_matrix)[1][1] 
-                elif svd_mode == 1:
-                    svd = TruncatedSVD(n_components=2, n_iter=5, random_state=42)
-                    svd.fit(RA_matrix)
-                    svd2_val = svd.singular_values_[1] 
-                elif svd_mode == 2: 
-                    if RA_matrix.shape[0] <= 2:
-                        copy_RA = np.append(RA_matrix, [[0]*97], axis=0)
-                    else:
-                        copy_RA = RA_matrix
-                    s = svds(copy_RA, k=2)[1]
+                s = scipy_svd(RA_matrix, compute_uv=False, check_finite=False)
+                if len(s) > 1:
+                    svd2_val = s[1]
+                else:
                     svd2_val = s[0]
-                elif svd_mode == 3:
-                    s = scipy_svd(RA_matrix, compute_uv=False, check_finite=False)
-                    if len(s) > 1:
-                        svd2_val = s[1]
-                    else:
-                        svd2_val = s[0]
                 
                     
                 lambda_matrix_arr[i_count, j_count] = lambda_matrix_arr[

--- a/cassiopeia/solver/SpectralNeighborJoiningSolver.py
+++ b/cassiopeia/solver/SpectralNeighborJoiningSolver.py
@@ -2,23 +2,23 @@
 This file stores a subclass of DistanceSolver, SpectralNeighborJoining. This algorithm is based on the one developed by Jaffe, et al. (2020) in their paper titled "Spectral neighbor joining for reconstruction of latent tree models. 
 """
 
-
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import abc
 import networkx as nx
 import numpy as np
 import pandas as pd
+from itertools import chain
 
 from cassiopeia.data import CassiopeiaTree
 from cassiopeia.solver import (
-    DistanceSolver,
+    NeighborJoiningSolver,
     dissimilarity_functions,
     solver_utilities,
 )
 
 
-class SpectralNeighborJoiningSolver(DistanceSolver.DistanceSolver):
+class SpectralNeighborJoiningSolver(NeighborJoiningSolver):
     """
     Spectral Neighbor-joining class for Cassiopeia.
 
@@ -26,17 +26,203 @@ class SpectralNeighborJoiningSolver(DistanceSolver.DistanceSolver):
 
     Args:
         dissimilarity_function: A function by which to compute the dissimilarity map, corresponding to the affinity R(i, j) in Jaffe et al. (2020). By default we will use exp(-d(i,j)) where d is the metric given by weighted_hamming_distance from dissimilarity functions without weights given.
-
-
-
     """
 
     def __init__(
         self,
         dissimilarity_function: Optional[
             Callable[
-                [np.array, np.array, int, Dict[int, Dict[int, float]]], float
+                [np.ndarray, np.ndarray, int, Dict[int, Dict[int, float]]], float
             ]
         ] = dissimilarity_functions.weighted_hamming_distance,
+        add_root: bool = False,
+        prior_transformation: str = "negative_log",
     ):
-        super().__init__(dissimilarity_function=dissimilarity_function)
+        super().__init__(dissimilarity_function, add_root=add_root, prior_transformation=prior_transformation) #type: ignore
+
+
+    def find_cherry(self, dissimilarity_matrix: np.ndarray, lambda_indices: List[List[int]] = None) -> Tuple[int, int]:
+        """Finds a pair of samples to join into a cherry.
+
+        Proceeds by minimizing the second largest SVD of the RA Matrix of some subset of nodes.
+
+        Args:
+            dissimilarity_matrix: A sample x sample dissimilarity matrix
+
+        Returns:
+            A tuple of intgers representing rows in the dissimilarity matrix
+                to join.
+        """
+        # temp? to pass tests
+        if not lambda_indices:
+            lambda_indices = [[i] for i in range(dissimilarity_matrix.shape[0])]
+
+        lambda_matrix = self.__compute_lambda(dissimilarity_matrix, lambda_indices)
+        np.fill_diagonal(lambda_matrix, np.inf)
+
+        return np.unravel_index(np.argmin(lambda_matrix, axis=None), lambda_matrix.shape) # TODO: cache with heapq?
+
+
+    def __compute_lambda(self, dissimilarity_map: np.ndarray, lambda_indices: List[List[int]]) -> np.ndarray:
+        """Computes the lambda matrix, whose entries consist of the second SVD of the R^A affinity matrix for every pair of nodes.
+
+        Computes the lambda(i,j) = SVD # 2 for R^(Ai U Aj) where i and j are the susbet indices in lambda_indices.
+
+        Args:
+            dissimilarity_map: A sample x sample dissimilarity map
+
+        Returns:
+            A matrix storing the Q-criterion for every pair of samples.
+        """
+
+        n = len(lambda_indices)
+        lambda_matrix = np.zeros([n, n])
+
+        for i_count, i in enumerate(lambda_indices):
+            for j_count, j in enumerate(lambda_indices):
+                if j_count >= i_count:
+                    break
+                
+                a_subset = [*i, *j]
+
+                # get complement
+                a_comp = lambda_indices.copy()
+                a_comp.pop(max(i_count, j_count))
+                a_comp.pop(min(i_count, j_count))
+                a_comp_flat = list(chain.from_iterable(a_comp))
+
+                # create RA matrix
+                RA_matrix = dissimilarity_map[np.ix_(a_subset, a_comp_flat)]
+
+                # Calculate SVD2
+                lambda_matrix[i_count, j_count] = lambda_matrix[j_count, i_count] = np.linalg.svd(RA_matrix)[1][1]
+
+        return lambda_matrix
+
+    def __update_lambda_indices(
+        self,
+        lambda_indices: List[List[int]],
+        node_names: np.ndarray,
+        cherry: Tuple[str, str],
+        new_node: str,
+        ) -> Tuple[List[List[int]], np.ndarray]:
+
+        lambda_indices_copy = lambda_indices.copy()
+
+        i, j = (
+            np.where(node_names == cherry[0])[0][0], # type: ignore
+            np.where(node_names == cherry[1])[0][0], # type: ignore
+        )
+
+        # modify names
+        node_names = np.append(node_names, new_node) # type: ignore
+        node_names = np.delete(node_names, [i, j])
+
+        # modify indices
+        lambda_indices_copy.append([*lambda_indices_copy[i], *lambda_indices_copy[j]])
+        lambda_indices_copy.pop(max(i, j))
+        lambda_indices_copy.pop(min(i, j))
+
+        return (lambda_indices_copy, node_names)
+
+
+    # TODO: document the change: just replace update dissimilarity map into update lambda_index matrix
+    def solve(
+        self,
+        cassiopeia_tree: CassiopeiaTree,
+        layer: Optional[str] = None,
+        collapse_mutationless_edges: bool = False,
+        logfile: str = "stdout.log",
+    ) -> None:
+        """Solves a tree for a general bottom-up distance-based solver routine.
+
+        The general solver routine proceeds by iteratively finding pairs of
+        samples to join together into a "cherry" and then reform the
+        dissimilarity matrix with respect to this new cherry. The implementation
+        of how to find cherries and update the dissimilarity map is left to
+        subclasses of DistanceSolver. The function will update the `tree`
+        attribute of the input CassiopeiaTree.
+
+        Args:
+            cassiopeia_tree: CassiopeiaTree object to be populated
+            layer: Layer storing the character matrix for solving. If None, the
+                default character matrix is used in the CassiopeiaTree.
+            collapse_mutationless_edges: Indicates if the final reconstructed
+                tree should collapse mutationless edges based on internal states
+                inferred by Camin-Sokal parsimony. In scoring accuracy, this
+                removes artifacts caused by arbitrarily resolving polytomies.
+            logfile: File location to log output. Not currently used.
+        """
+        node_name_generator = solver_utilities.node_name_generator()
+
+        self.setup_dissimilarity_map(cassiopeia_tree, layer)
+
+        dissimilarity_map = cassiopeia_tree.get_dissimilarity_map()
+
+        N = dissimilarity_map.shape[0]
+
+        # instantiate a dissimilarity map that can be updated as we join
+        # together nodes.
+        _dissimilarity_map = dissimilarity_map.copy()
+
+        # instantiate a tree where all samples appear as leaves.
+        tree = nx.Graph()
+        tree.add_nodes_from(_dissimilarity_map.index)
+
+        # Construct Lambda Indices matrix
+        lambda_indices: List[List[int]] = [[i] for i in range(N)]
+        node_names: np.ndarray = _dissimilarity_map.index.values
+
+        while N > 2:
+            print(f'# Running with N={N}')
+            i, j = self.find_cherry(_dissimilarity_map.to_numpy(), lambda_indices)
+
+            # get node names to join
+            node_i, node_j = (
+                node_names[i],
+                node_names[j],
+            ) 
+
+            new_node_name = next(node_name_generator)
+            tree.add_node(new_node_name)
+            tree.add_edges_from([
+                (new_node_name, node_i), 
+                (new_node_name, node_j)
+            ])
+
+            # Changed for SNJ
+            lambda_indices, node_names = self.__update_lambda_indices(
+                    lambda_indices, 
+                    node_names,
+                    (node_i, node_j), 
+                    new_node_name
+                )
+
+            N = len(lambda_indices)
+
+        tree = self.root_tree(
+            tree,
+            cassiopeia_tree.root_sample_name,
+            node_names,
+        )
+
+        # remove root from character matrix before populating tree
+        if (
+            cassiopeia_tree.root_sample_name
+            in cassiopeia_tree.character_matrix.index
+        ):
+            cassiopeia_tree.character_matrix = (
+                cassiopeia_tree.character_matrix.drop(
+                    index=cassiopeia_tree.root_sample_name
+                )
+            )
+
+        cassiopeia_tree.populate_tree(tree, layer=layer)
+        cassiopeia_tree.collapse_unifurcations()
+
+        # collapse mutationless edges
+        if collapse_mutationless_edges:
+            cassiopeia_tree.collapse_mutationless_edges(
+                infer_ancestral_characters=True
+            )
+

--- a/cassiopeia/solver/SpectralNeighborJoiningSolver.py
+++ b/cassiopeia/solver/SpectralNeighborJoiningSolver.py
@@ -1,0 +1,42 @@
+"""
+This file stores a subclass of DistanceSolver, SpectralNeighborJoining. This algorithm is based on the one developed by Jaffe, et al. (2020) in their paper titled "Spectral neighbor joining for reconstruction of latent tree models. 
+"""
+
+
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+import abc
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+from cassiopeia.data import CassiopeiaTree
+from cassiopeia.solver import (
+    DistanceSolver,
+    dissimilarity_functions,
+    solver_utilities,
+)
+
+
+class SpectralNeighborJoiningSolver(DistanceSolver.DistanceSolver):
+    """
+    Spectral Neighbor-joining class for Cassiopeia.
+
+    Implements a variation on the Spectral Neighbor-Joining algorithm described by Jaffe et al. in their 2020 paper. This class implements the abstract class DistanceSolver. This class inherits the 'solve' method from DistanceSolver with the find_cherry method implemented using a spectral method as in Jaffe et al. (2020).
+
+    Args:
+        dissimilarity_function: A function by which to compute the dissimilarity map, corresponding to the affinity R(i, j) in Jaffe et al. (2020). By default we will use exp(-d(i,j)) where d is the metric given by weighted_hamming_distance from dissimilarity functions without weights given.
+
+
+
+    """
+
+    def __init__(
+        self,
+        dissimilarity_function: Optional[
+            Callable[
+                [np.array, np.array, int, Dict[int, Dict[int, float]]], float
+            ]
+        ] = dissimilarity_functions.weighted_hamming_distance,
+    ):
+        super().__init__(dissimilarity_function=dissimilarity_function)

--- a/cassiopeia/solver/SpectralNeighborJoiningSolver.py
+++ b/cassiopeia/solver/SpectralNeighborJoiningSolver.py
@@ -1,18 +1,17 @@
 """
 This file stores a subclass of DistanceSolver, SpectralNeighborJoining. This 
-algorithm is based on the one developed by Jaffe, et al. (2020) in their paper 
-titled "Spectral neighbor joining for reconstruction of latent tree models. 
+algorithm is based on the one developed by Jaffe, et al. (2021) in their paper 
+titled "Spectral neighbor joining for reconstruction of latent tree models",
+published in the SIAM Journal for Math and Data Science. 
+ 
 """
 
 import itertools
-from typing import Callable, Dict, List, Optional, Tuple
-
-from itertools import chain
 import networkx as nx
 import numpy as np
 import pandas as pd
 from scipy.linalg import svd
-
+from typing import Callable, Dict, List, Optional, Tuple
 
 from cassiopeia.solver.DistanceSolver import DistanceSolver, DistanceSolverError
 
@@ -25,31 +24,52 @@ from cassiopeia.solver import (
 
 class SpectralNeighborJoiningSolver(DistanceSolver):
     """
-    Spectral Neighbor-joining class for Cassiopeia.
+    Spectral Neighbor-Joining class for Cassiopeia.
 
-    Implements a variation on the Spectral Neighbor-Joining algorithm described by Jaffe et al. in their 2020 paper. This class implements the abstract class DistanceSolver. This class inherits the 'solve' method from DistanceSolver with the find_cherry method implemented using a spectral method as in Jaffe et al. (2020).
+    Implements a variation on the Spectral Neighbor-Joining
+    algorithm described by Jaffe et al. in their 2020 paper. This class
+    implements the abstract class DistanceSolver. This class inherits
+    the 'solve' method from DistanceSolver with the 'find_cherry' method
+    implemented using a spectral method as in Jaffe et al.  (2020).
 
     Args:
-        dissimilarity_function: A function by which to compute the dissimilarity map, corresponding to the affinity R(i, j) in Jaffe et al. (2020). By default we will use exp(-d(i,j)) where d is the metric given by weighted_hamming_distance from dissimilarity functions without weights given.
+        similarity_function: A function by which to compute the similarity map,
+            corresponding to the affinity R(i, j) in Jaffe et al.
+            (2020). Note that this similarity score should be multiplicative,
+            i.e. R(i, j) = R(i, k) * R(k, j) for k on the path from i to j on
+            the lineage tree. By default we will use exp(-d(i,j)) where d is the
+            metric given by weighted_hamming_distance from
+            dissimilarity_functions without weights given.
+
+        add_root: Whether or not to add an implicit root to the tree, i.e. a
+            root with unmutated characters.
+        prior_transformation: Function to use when transforming
+            priors into weights
     """
 
     def __init__(
         self,
-        dissimilarity_function: Optional[
+        similarity_function: Optional[
             Callable[
                 [np.ndarray, np.ndarray, int, Dict[int, Dict[int, float]]],
                 float,
             ]
-        ] = dissimilarity_functions.exponential_negative_hamming_distance, # type: ignore
+        ] = dissimilarity_functions.exponential_negative_hamming_distance,
+        # type: ignore
         add_root: bool = False,
         prior_transformation: str = "negative_log",
     ):
-        super().__init__(dissimilarity_function, add_root=add_root, prior_transformation=prior_transformation)  # type: ignore
+        super().__init__(
+            dissimilarity_function=similarity_function,
+            add_root=add_root,
+            prior_transformation=prior_transformation,
+        )  # type: ignore
 
     def get_dissimilarity_map(
         self, cassiopeia_tree: CassiopeiaTree, layer: Optional[str] = None
     ) -> pd.DataFrame:
-        """Outputs the first lambda matrix, where every subset is an individual node.
+        """Outputs the first lambda matrix, where every subset is an
+        individual node.
 
         Args:
             cassiopeia_tree: the CassiopeiaTree object passed into solve()
@@ -57,10 +77,11 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
                 default character matrix is used in the CassiopeiaTree.
 
         Returns:
-            DataFrame object of the lamba matrix, but similar in structure to DistanceSolver's dissimilarity_map.
+            DataFrame object of the lambda matrix, but similar in structure to
+                DistanceSolver's dissimilarity_map.
         """
 
-        # get similarity map and save it as private instance variable
+        # get dissimilarity map and save it as private instance variable
         self._similarity_map = super().get_dissimilarity_map(
             cassiopeia_tree, layer
         )
@@ -77,8 +98,7 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
                 continue
 
             svd2_val = self._compute_svd2(
-                pair=(i_idx, j_idx),
-                lambda_indices=self.lambda_indices
+                pair=(i_idx, j_idx), lambda_indices=self.lambda_indices
             )
 
             lambda_matrix_arr[i_idx, j_idx] = lambda_matrix_arr[
@@ -97,32 +117,34 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
     def find_cherry(self, dissimilarity_map: np.ndarray) -> Tuple[int, int]:
         """Finds a pair of samples to join into a cherry.
 
-        With dissimilarity_map being the lambda matrix, this method finds the argmin pair of subsets of the lambda matrix.
+        With dissimilarity_map being the lambda matrix, this method finds the
+            argmin pair of subsets of the lambda matrix.
 
         Args:
             dissimilarity_matrix: Lambda matrix
 
         Returns:
-            A tuple of intgers representing rows in the dissimilarity matrix
-                to join.
+            A tuple of integers representing rows in the
+            dissimilarity matrix to join.
         """
 
         return np.unravel_index(
             np.argmin(dissimilarity_map, axis=None), dissimilarity_map.shape
-        ) # type: ignore
+        )  # type: ignore
 
     def _compute_svd2(
         self, pair: Tuple[int, int], lambda_indices: List[List[int]]
     ) -> float:
-        """Computes the second largest SVD of a pair of subset's RA matrix.
+        """Computes the second largest singular value of a pair of
+        subset's RA matrix.
 
         Args:
             pair (Tuple[int, int]): pair of indices i and j where i > j.
-            lambda_indices (List[List[int]]): the list of subsets for 
+            lambda_indices (List[List[int]]): the list of subsets for
                 which 'pair' refers to. len(lambda_indices) >= 3
 
         Returns:
-            float: The second largest SVD of the pair's RA matrix.
+            float: The second largest singular value of the pair's RA matrix.
         """
         i_idx, j_idx = pair
         i_sub, j_sub = lambda_indices[i_idx], lambda_indices[j_idx]
@@ -134,12 +156,10 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
         a_comp = lambda_indices.copy()
         a_comp.pop(i_idx)
         a_comp.pop(j_idx)
-        a_comp_flat = list(chain.from_iterable(a_comp))
+        a_comp_flat = list(itertools.chain.from_iterable(a_comp))
 
         # reconstruct RA matrix
-        RA_matrix = self._similarity_map.values[
-            np.ix_(a_subset, a_comp_flat)
-        ]
+        RA_matrix = self._similarity_map.values[np.ix_(a_subset, a_comp_flat)]
 
         # get second largest SVD if available, first if not.
         s = svd(RA_matrix, compute_uv=False, check_finite=False)
@@ -149,14 +169,14 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
 
     def update_dissimilarity_map(
         self,
-        dissimilarity_map: pd.DataFrame,  # lambda matrix
+        similarity_map: pd.DataFrame,  # lambda matrix
         cherry: Tuple[str, str],
         new_node: str,
     ) -> pd.DataFrame:
         """Updates the lambda matrix using the pair of subsets from find_cherry.
 
         Args:
-            dissimilarity_map: lambda matrix to update
+            similarity_map: lambda matrix to update
             cherry1: One of the children to join.
             cherry2: One of the children to join.
             new_node: New node name to add to the dissimilarity map
@@ -166,12 +186,12 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
         """
         # get cherry nodes in index of lambda matrix
         i, j = (
-            np.where(dissimilarity_map.index == cherry[0])[0][0],
-            np.where(dissimilarity_map.index == cherry[1])[0][0],
+            np.where(similarity_map.index == cherry[0])[0][0],
+            np.where(similarity_map.index == cherry[1])[0][0],
         )
 
         # modify names
-        node_names = dissimilarity_map.index.values
+        node_names = similarity_map.index.values
         node_names = np.append(node_names, new_node)
         node_names = np.delete(node_names, [i, j])
 
@@ -181,40 +201,41 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
         )
         self.lambda_indices.pop(max(i, j))
         self.lambda_indices.pop(min(i, j))
-    
+
         # new lambda indiices
         N = len(self.lambda_indices)
 
         if N <= 2:
             return pd.DataFrame(
-                np.zeros([N, N]), 
-                index=node_names, 
-                columns=node_names
+                np.zeros([N, N]), index=node_names, columns=node_names
             )
 
-        # get the old lambda matrix 
-        lambda_matrix_arr = dissimilarity_map.drop(
-            index=[cherry[0], cherry[1]],
-            columns=[cherry[0], cherry[1]]
+        # get the old lambda matrix
+        lambda_matrix_arr = similarity_map.drop(
+            index=[cherry[0], cherry[1]], columns=[cherry[0], cherry[1]]
         ).values
 
         # add new col + row to lambda matrix
         new_row = np.array([0.0] * (N - 1))
-        lambda_matrix_arr = np.vstack((lambda_matrix_arr, np.atleast_2d(new_row)))
+        lambda_matrix_arr = np.vstack(
+            (lambda_matrix_arr, np.atleast_2d(new_row))
+        )
         new_col = np.array([0.0] * N)
-        lambda_matrix_arr = np.array(np.hstack((lambda_matrix_arr, np.atleast_2d(new_col).T))) # type: ignore
-        
+        lambda_matrix_arr = np.array(
+            np.hstack((lambda_matrix_arr, np.atleast_2d(new_col).T))
+        )
+        # type: ignore
+
         # compute new SVDs
         i_idx = N - 1
-        for j_idx in range(i_idx): 
+        for j_idx in range(i_idx):
             svd2_val = self._compute_svd2(
-                pair=(i_idx, j_idx),
-                lambda_indices=self.lambda_indices
+                pair=(i_idx, j_idx), lambda_indices=self.lambda_indices
             )
 
             lambda_matrix_arr[i_idx, j_idx] = lambda_matrix_arr[
                 j_idx, i_idx
-            ] = svd2_val 
+            ] = svd2_val
 
         np.fill_diagonal(lambda_matrix_arr, np.inf)
 
@@ -226,13 +247,16 @@ class SpectralNeighborJoiningSolver(DistanceSolver):
         return lambda_matrix_df
 
     def setup_root_finder(self, cassiopeia_tree: CassiopeiaTree) -> None:
-        """Defines the implicit rooting strategy for the NeighborJoiningSolver.
+        """Defines the implicit rooting strategy for the
+        SpectralNeighborJoiningSolver.  See 'setup_root_finder' in
+        NeighborJoiningSolver.
 
-        By default, the SpectralNeighborJoining algorithm returns an unrooted tree.
-        To root this tree, an implicit root of all zeros is added to the
-        character matrix. Then, the dissimilarity map is recalculated using
-        the updated character matrix. If the tree already has a computed
-        dissimilarity map, only the new dissimilarities are calculated.
+        By default, the SpectralNeighborJoining algorithm returns an
+        unrooted tree.  To root this tree, an implicit root of all zeros is
+        added to the character matrix. Then, the dissimilarity map is
+        recalculated using the updated character matrix. If the tree already
+        has a computed dissimilarity map, only the new similarities are
+        calculated.
 
         Args:
             cassiopeia_tree: Input CassiopeiaTree to `solve`

--- a/cassiopeia/solver/__init__.py
+++ b/cassiopeia/solver/__init__.py
@@ -15,4 +15,5 @@ from .SpectralGreedySolver import SpectralGreedySolver
 from .SpectralSolver import SpectralSolver
 from .UPGMASolver import UPGMASolver
 from .VanillaGreedySolver import VanillaGreedySolver
+from .SpectralNeighborJoiningSolver import SpectralNeighborJoiningSolver
 from . import dissimilarity_functions as dissimilarity

--- a/cassiopeia/solver/dissimilarity_functions.py
+++ b/cassiopeia/solver/dissimilarity_functions.py
@@ -238,6 +238,7 @@ def weighted_hamming_similarity(
 
     return d / num_present
 
+
 def exponential_negative_hamming_distance(
     s1: List[int],
     s2: List[int],
@@ -245,23 +246,27 @@ def exponential_negative_hamming_distance(
     weights: Optional[Dict[int, Dict[int, float]]] = None,
 ) -> float:
 
-
     """
-    Calculates the default affinity for SpectralNeighborJoiningSolver. This simply returns exp(-d(i,j)) where d is the weighted_hamming_distance function as above where no weights are passed in.
-    In other words, we increment dissimilarity score d by +2 if the states are different, +1 if one state is uncut and the other is an indel, and +0 if the two states are identical. Then, we take this total d and return exp(-d).
+    Calculates the default affinity for SpectralNeighborJoiningSolver. This
+    simply returns exp(-d(i,j)) where d is the weighted_hamming_distance function as
+    above where no weights are passed in.  In other words, we increment d by +2 if
+    the states are different, +1 if one state is uncut and the other is an indel,
+    and +0 if the two states are identical. Then, we take this total d and return
+    exp(-d). Note that since d is a metric, 'exponential_negative_hamming_distance'
+    is a multiplicative similarity score, i.e. s(i, j) = s(i, k) * s(k, j) for k on
+    the path between i and j.
 
     Args:
         s1: Character states of the first sample
         s2: Character states of the second sample
         missing_state_indicator: The character representing missing values
-        weights: A dictionary storing the state weights for each character, derived
-            from the state priors. This should be a nested dictionary where each
-            key corresponds to character that then indexes another dictionary
-            storing the weight of each observed state.
-            (Character -> State -> Weight)
+        weights: A dictionary storing the state weights for each character, derived from
+            the state priors. This should be a nested dictionary where each key corresponds
+            to character that then indexes another dictionary storing the weight of each
+            observed state.  (Character -> State -> Weight)
 
     Returns:
-        A dissimilarity score.
+        A similarity score.
     """
 
     d = 0
@@ -293,7 +298,7 @@ def exponential_negative_hamming_distance(
 
     weighted_hamm_dist = d / num_present
 
-    return np.exp( - weighted_hamm_dist ) # 2.718281828459045
+    return np.exp(-weighted_hamm_dist)
 
 
 def cluster_dissimilarity(

--- a/cassiopeia/solver/dissimilarity_functions.py
+++ b/cassiopeia/solver/dissimilarity_functions.py
@@ -264,7 +264,36 @@ def exponential_negative_hamming_distance(
         A dissimilarity score.
     """
 
-    return 2.718281828459045 ** (- weighted_hamming_distance(s1, s2, missing_state_indicator=missing_state_indicator))
+    d = 0
+    num_present = 0
+    for i in range(len(s1)):
+
+        if s1[i] == missing_state_indicator or s2[i] == missing_state_indicator:
+            continue
+
+        num_present += 1
+
+        if s1[i] != s2[i]:
+            if s1[i] == 0 or s2[i] == 0:
+                if weights:
+                    if s1[i] != 0:
+                        d += weights[i][s1[i]]
+                    else:
+                        d += weights[i][s2[i]]
+                else:
+                    d += 1
+            else:
+                if weights:
+                    d += weights[i][s1[i]] + weights[i][s2[i]]
+                else:
+                    d += 2
+
+    if num_present == 0:
+        return 0
+
+    weighted_hamm_dist = d / num_present
+
+    return np.exp( - weighted_hamm_dist ) # 2.718281828459045
 
 
 def cluster_dissimilarity(

--- a/cassiopeia/solver/dissimilarity_functions.py
+++ b/cassiopeia/solver/dissimilarity_functions.py
@@ -238,6 +238,34 @@ def weighted_hamming_similarity(
 
     return d / num_present
 
+def exponential_negative_hamming_distance(
+    s1: List[int],
+    s2: List[int],
+    missing_state_indicator=-1,
+    weights: Optional[Dict[int, Dict[int, float]]] = None,
+) -> float:
+
+
+    """
+    Calculates the default affinity for SpectralNeighborJoiningSolver. This simply returns exp(-d(i,j)) where d is the weighted_hamming_distance function as above where no weights are passed in.
+    In other words, we increment dissimilarity score d by +2 if the states are different, +1 if one state is uncut and the other is an indel, and +0 if the two states are identical. Then, we take this total d and return exp(-d).
+
+    Args:
+        s1: Character states of the first sample
+        s2: Character states of the second sample
+        missing_state_indicator: The character representing missing values
+        weights: A dictionary storing the state weights for each character, derived
+            from the state priors. This should be a nested dictionary where each
+            key corresponds to character that then indexes another dictionary
+            storing the weight of each observed state.
+            (Character -> State -> Weight)
+
+    Returns:
+        A dissimilarity score.
+    """
+
+    return np.exp(-1 * weighted_hamming_distance(s1, s2, missing_state_indicator=missing_state_indicator))
+
 
 def cluster_dissimilarity(
     dissimilarity_function: Callable[

--- a/cassiopeia/solver/dissimilarity_functions.py
+++ b/cassiopeia/solver/dissimilarity_functions.py
@@ -264,7 +264,7 @@ def exponential_negative_hamming_distance(
         A dissimilarity score.
     """
 
-    return np.exp(-1 * weighted_hamming_distance(s1, s2, missing_state_indicator=missing_state_indicator))
+    return 2.718281828459045 ** (- weighted_hamming_distance(s1, s2, missing_state_indicator=missing_state_indicator))
 
 
 def cluster_dissimilarity(

--- a/cassiopeia/tl.py
+++ b/cassiopeia/tl.py
@@ -1,1 +1,2 @@
 from cassiopeia.tools import *
+# redundant comment

--- a/cassiopeia/tl.py
+++ b/cassiopeia/tl.py
@@ -1,2 +1,1 @@
 from cassiopeia.tools import *
-# redundant comment

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -224,7 +224,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
 
         svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
 
-        expected_q = pd.DataFrame(
+        expected_lambda_matrix = pd.DataFrame(
             [
                 [
                     np.inf,
@@ -266,7 +266,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["state0", "state2", "state3", "state4", "state5"],
         )
 
-        self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
+        self.assertTrue(np.allclose(svd2_vals, expected_lambda_matrix, atol=0.1))
 
     def test_compute_lambda_N3(self):
         """Test lamba matrix output for when there are 3 subsets left."""
@@ -277,7 +277,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
 
         svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
 
-        expected_q = np.array(
+        expected_lambda_matrix = np.array(
             [
                 [np.inf, 4.51233062e-17, 4.51233062e-17],
                 [4.51233062e-17, np.inf, 7.77014257e-01],
@@ -285,7 +285,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
+        self.assertTrue(np.allclose(svd2_vals, expected_lambda_matrix, atol=0.1))
 
     def test_update_dissimilarity_map_base(self):
         """Test the update method's lambda matrix output."""

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -2,25 +2,34 @@
 Test SpectralNeighborJoiningSolver in Cassiopeia.solver.
 """
 import unittest
-from typing import Dict, Optional
+from typing import List
 from unittest import mock
-
 import itertools
 import networkx as nx
+from networkx.classes.digraph import DiGraph
 import numpy as np
-from numpy.testing._private.utils import assert_equal
 import pandas as pd
-import matplotlib.pyplot as plt
 
 # Only for debugging purposes
-# if True:
-#     import sys
-#     sys.path.insert(0, '../..')
+if True:
+    import sys
+
+    sys.path.insert(0, "../..")
 
 import cassiopeia as cas
-from cassiopeia.solver.dissimilarity_functions import exponential_negative_hamming_distance
+
 
 def find_triplet_structure(triplet, T):
+    """Identify the two nodes with the most similar ancestry.
+
+    Args:
+        triplet (str): name of nodes to check
+        T (tree): tree in which the nodes are in
+
+    Returns:
+        str: the two nodes that have the most similar number of
+            common ancestors.
+    """
     a, b, c = triplet[0], triplet[1], triplet[2]
     a_ancestors = [node for node in nx.ancestors(T, a)]
     b_ancestors = [node for node in nx.ancestors(T, b)]
@@ -38,9 +47,32 @@ def find_triplet_structure(triplet, T):
     return structure
 
 
+def assertTripletCorrectness(
+    self, nodes: List[str], expected_tree: DiGraph, observed_tree: DiGraph
+):
+    """Checks whether two trees are identical regardless of internal node names.
+
+    Args:
+        nodes (List[str]): List of leaf nodes to get triplets from.
+        expected_tree (DiGraph): expected tree that contains the leaf nodes.
+        observed_tree (DiGraph): observed tree that contain the same leaf nodes.
+    """
+    # generate triplets
+    triplets = itertools.combinations(nodes, 3)
+
+    # check each triplet
+    for triplet in triplets:
+        expected_triplet = find_triplet_structure(triplet, expected_tree)
+        observed_triplet = find_triplet_structure(triplet, observed_tree)
+        self.assertEqual(expected_triplet, observed_triplet)
+
+
 class TestSpectralNeighborJoiningSolver(unittest.TestCase):
     def setUp(self):
-        self.snj_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=True)
+        """Instantiate instance variables for repeated use in tests."""
+        self.snj_solver = cas.solver.SpectralNeighborJoiningSolver(
+            add_root=True
+        )
 
         # --------------------- General SNJ ---------------------
         cm_general = pd.DataFrame.from_dict(
@@ -54,65 +86,29 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             orient="index",
             columns=["x1", "x2", "x3"],
         )
-        sim_general = pd.DataFrame.from_dict(
-            {
-                "a": [0.0, 1/3, 1.0, 1.0, 2/3],
-                "b": [1/3, 0.0, 4/3, 2/3, 1.0],
-                "c": [1.0, 4/3, 0.0, 2.0, 1.0],
-                "d": [1.0, 2/3, 2.0, 0.0, 1.0],
-                "e": [2/3, 1.0, 1.0, 1.0, 0.0],
-            },
-            orient="index",
+
+        sim_general = pd.DataFrame(
+            [
+                [0.0, 0.51341712, 0.36787944, 0.36787944, 0.26359714],
+                [0.51341712, 0.0, 0.71653131, 0.36787944, 0.26359714],
+                [0.36787944, 0.71653131, 0.0, 0.26359714, 0.1888756],
+                [0.36787944, 0.36787944, 0.26359714, 0.0, 0.71653131],
+                [0.26359714, 0.26359714, 0.1888756, 0.71653131, 0.0],
+            ],
+            index=["a", "b", "c", "d", "e"],
             columns=["a", "b", "c", "d", "e"],
         )
 
         self.cm_general = cm_general
         self.sim_general = sim_general
         self.tree_general = cas.data.CassiopeiaTree(
-            character_matrix=cm_general, dissimilarity_map=sim_general, root_sample_name="b"
+            character_matrix=cm_general,
+            dissimilarity_map=sim_general,
+            root_sample_name="b",
         )
 
-        # ---------------- SNJ Integration Test 1 ----------------
-        cm_i1 = pd.DataFrame.from_dict(
-            {
-                "a": [1, 1, 1, 0], 
-                "b": [1, 1, 2, 1],
-                "c": [1, 1, 2, 2],
-                "d": [1, 2, 0, 0],
-                "e": [2, 3, 0, 0],
-                "f": [2, 4, 3, 0],
-                "g": [2, 4, 4, 0]
-            },
-            orient="index",
-            columns=["x1", "x2", "x3", "x4"],
-        )
-        
-        self.itree_a = cas.data.CassiopeiaTree(character_matrix=cm_i1)
-
-
-
-        # --------------- SNJ Integration Test 2 ----------------
-        cm_i2 = pd.DataFrame.from_dict(
-            {
-                "a": [1, 1, 3, 3, 1],
-                "b": [1, 1, 3, 3, 2],
-                "c": [1, 1, 3, 4, 0],
-                "d": [1, 1, 4, 0, 0],
-                "e": [1, 2, 0, 0, 0],
-                "f": [2, 3, 2, 1, 0],
-                "g": [2, 3, 2, 2, 0],
-                "h": [2, 3, 1, 0, 0],
-                "i": [2, 4, 6, 0, 0],
-                "j": [2, 4, 5, 0, 0]
-            },
-            orient="index",
-            columns=["x1", "x2", "x3", "x4", "x5"]
-        )
-        
-        self.itree_b = cas.data.CassiopeiaTree(character_matrix=cm_i2)
-
-        # ---------------- Lineage Tracing SNJ ----------------
-        cm_lineage = pd.DataFrame.from_dict(
+        # ---------------- Perfect Phylogeny ----------------
+        cm_pp = pd.DataFrame.from_dict(
             {
                 "a": [1, 1, 0],
                 "b": [1, 2, 0],
@@ -124,9 +120,46 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["x1", "x2", "x3"],
         )
 
-        self.tree_lineage = cas.data.CassiopeiaTree(character_matrix=cm_lineage)
+        self.tree_pp = cas.data.CassiopeiaTree(character_matrix=cm_pp)
 
-        # ------------- CM with Duplicates -----------------------
+        # ---------------- SNJ Integration Test 1 ----------------
+        self.cm_int1 = pd.DataFrame.from_dict(
+            {
+                "a": [1, 1, 1, 0],
+                "b": [1, 1, 2, 1],
+                "c": [1, 1, 2, 2],
+                "d": [1, 2, 0, 0],
+                "e": [2, 3, 0, 0],
+                "f": [2, 4, 3, 0],
+                "g": [2, 4, 4, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3", "x4"],
+        )
+
+        self.tree_int1 = cas.data.CassiopeiaTree(character_matrix=self.cm_int1)
+
+        # --------------- SNJ Integration Test 2 ----------------
+        cm_int2 = pd.DataFrame.from_dict(
+            {
+                "a": [1, 1, 3, 3, 1],
+                "b": [1, 1, 3, 3, 2],
+                "c": [1, 1, 3, 4, 0],
+                "d": [1, 1, 4, 0, 0],
+                "e": [1, 2, 0, 0, 0],
+                "f": [2, 3, 2, 1, 0],
+                "g": [2, 3, 2, 2, 0],
+                "h": [2, 3, 1, 0, 0],
+                "i": [2, 4, 6, 0, 0],
+                "j": [2, 4, 5, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3", "x4", "x5"],
+        )
+
+        self.tree_int2 = cas.data.CassiopeiaTree(character_matrix=cm_int2)
+
+        # ------------- Duplicate Nodes -----------------------
         cm_dupe = pd.DataFrame.from_dict(
             {
                 "a": [1, 1, 0],
@@ -140,17 +173,16 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["x1", "x2", "x3"],
         )
 
-        self.tree_dupe = cas.data.CassiopeiaTree(
-            character_matrix=cm_dupe
-        )
+        self.tree_dupe = cas.data.CassiopeiaTree(character_matrix=cm_dupe)
 
-        # ------------- SNJ with modified hamming dissimilarity ------------
+        # ------- Perfect Phylogenetic Tree + Priors --------
         priors = {0: {1: 0.5, 2: 0.5}, 1: {1: 0.2, 2: 0.8}, 2: {1: 0.3, 2: 0.7}}
-        self.tree_lineage_priors = cas.data.CassiopeiaTree(
-            character_matrix=cm_lineage, priors=priors
+        self.tree_pp_priors = cas.data.CassiopeiaTree(
+            character_matrix=cm_pp, priors=priors
         )
 
     def test_constructor(self):
+        """Test for errors related to rooting trees."""
         self.assertIsNotNone(self.snj_solver.dissimilarity_function)
         self.assertIsNotNone(self.tree_general.get_dissimilarity_map())
 
@@ -180,162 +212,267 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
         with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError):
             nothing_solver.solve(root_only_tree)
 
-        snj_solver_fn = cas.solver.SpectralNeighborJoiningSolver(
-            add_root=True 
-        ) 
+        snj_solver_fn = cas.solver.SpectralNeighborJoiningSolver(add_root=True)
         snj_solver_fn.solve(self.tree_general)
 
         self.assertEqual(
-            self.tree_general.get_dissimilarity_map().loc["a", "b"], 1/3
+            self.tree_general.get_dissimilarity_map().loc["a", "b"], 0.51341712
         )
 
     def test_compute_lambda_pairwise(self):
-        self.lambda_pairwise = [[i] for i in range(self.sim_general.values.shape[0])]
+        """Test lambda matrix output for subsets of length 1."""
+        self.lambda_pairwise = [
+            [i] for i in range(self.sim_general.values.shape[0])
+        ]
 
         # run to generate similarity map
-        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
+        self.snj_solver.get_dissimilarity_map(self.tree_pp)
 
         svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
 
-        expected_q = pd.DataFrame.from_dict(
-            {
-                "state0": [np.inf, 0.43661943, 0.31344894, 0.7780976 , 0.67849699],
-                "state1": [0.43661943, np.inf, 0.09190727, 1.01535639, 0.86536494],
-                "state2": [0.31344894, 0.09190727, np.inf, 0.95520247, 1.01083351],
-                "state3": [0.7780976 , 1.01535639, 0.95520247, np.inf, 0.04942259],
-                "state4": [0.67849699, 0.86536494, 1.01083351, 0.04942259, np.inf],
-            },
-            orient="index",
+        expected_q = pd.DataFrame(
+            [
+                [
+                    np.inf,
+                    1.55149248e-01,
+                    1.53000012e-01,
+                    3.20069389e-01,
+                    3.25748924e-01,
+                ],
+                [
+                    1.55149248e-01,
+                    np.inf,
+                    3.23322617e-17,
+                    4.60567417e-01,
+                    4.59750018e-01,
+                ],
+                [
+                    1.53000012e-01,
+                    3.23322617e-17,
+                    np.inf,
+                    4.44601551e-01,
+                    4.57653028e-01,
+                ],
+                [
+                    3.20069389e-01,
+                    4.60567417e-01,
+                    4.44601551e-01,
+                    np.inf,
+                    3.23322617e-17,
+                ],
+                [
+                    3.25748924e-01,
+                    4.59750018e-01,
+                    4.57653028e-01,
+                    3.23322617e-17,
+                    np.inf,
+                ],
+            ],
+            index=["state0", "state2", "state3", "state4", "state5"],
             columns=["state0", "state2", "state3", "state4", "state5"],
         )
 
         self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
 
     def test_compute_lambda_N3(self):
+        """Test lamba matrix output for when there are 3 subsets left."""
         self.lambda_pairwise = [[0], [1, 2], [3, 4]]
 
         # run to generate similarity map
-        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
-        
+        self.snj_solver.get_dissimilarity_map(self.tree_pp)
+
         svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
 
-        expected_q = np.array([
-            [np.inf, 0.04942259, 0.09190727],
-            [0.04942259, np.inf, 2.05480467],
-            [0.09190727, 2.05480467, np.inf]
-            ])
+        expected_q = np.array(
+            [
+                [np.inf, 4.51233062e-17, 4.51233062e-17],
+                [4.51233062e-17, np.inf, 7.77014257e-01],
+                [4.51233062e-17, 7.77014257e-01, np.inf],
+            ]
+        )
 
         self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
 
     def test_update_dissimilarity_map_base(self):
+        """Test the update method's lambda matrix output."""
         # run to generate similarity map
-        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
-        self.snj_solver.lambda_indices = [[0], [1], [2], [3], [4]]
-        lambda_matrix_arr = self.snj_solver.compute_lambda(
-            self.snj_solver.lambda_indices
-            )
-        
-        node_names = self.sim_general.index
-        lambda_matrix = pd.DataFrame(
-            lambda_matrix_arr, 
-            index=node_names, 
-            columns=node_names
-            )
+        lambda_matrix = self.snj_solver.get_dissimilarity_map(self.tree_pp)
 
         node_i, node_j = (
-                lambda_matrix.index[0],
-                lambda_matrix.index[1],
-            )
-        
-        svd2_vals = self.snj_solver.update_dissimilarity_map(
-            lambda_matrix,
-            (node_i, node_j),
-            'new_node'
+            lambda_matrix.index[0],
+            lambda_matrix.index[1],
         )
 
-        expected_lambda = np.array([
-            [np.inf, 0.95520247, 1.01083351, 0.04942259],
-            [0.95520247, np.inf, 0.04942259, 1.01083351],
-            [1.01083351, 0.04942259, np.inf, 0.95520247],
-            [0.04942259, 1.01083351, 0.95520247, np.inf]
-       ])
+        svd2_vals = self.snj_solver.update_dissimilarity_map(
+            lambda_matrix, (node_i, node_j), "new_node"
+        )
+
+        expected_lambda = np.array(
+            [
+                [
+                    np.inf,
+                    4.75160977e-01,
+                    4.69514735e-01,
+                    3.77716429e-01,
+                    1.35120582e-16,
+                ],
+                [
+                    4.75160977e-01,
+                    np.inf,
+                    1.58395087e-16,
+                    2.15559051e-01,
+                    4.68450526e-01,
+                ],
+                [
+                    4.69514735e-01,
+                    1.58395087e-16,
+                    np.inf,
+                    2.10372511e-01,
+                    4.45839079e-01,
+                ],
+                [
+                    3.77716429e-01,
+                    2.15559051e-01,
+                    2.10372511e-01,
+                    np.inf,
+                    3.81880809e-01,
+                ],
+                [
+                    1.35120582e-16,
+                    4.68450526e-01,
+                    4.45839079e-01,
+                    3.81880809e-01,
+                    np.inf,
+                ],
+            ]
+        )
 
         self.assertTrue(np.allclose(svd2_vals, expected_lambda, atol=0.1))
-        self.assertListEqual(svd2_vals.index.values.tolist(), ['c', 'd', 'e', 'new_node'])
-        self.assertListEqual(svd2_vals.columns.values.tolist(), ['c', 'd', 'e', 'new_node'])
+        self.assertListEqual(
+            svd2_vals.index.values.tolist(), ["c", "d", "e", "root", "new_node"]
+        )
+        self.assertListEqual(
+            svd2_vals.columns.values.tolist(),
+            ["c", "d", "e", "root", "new_node"],
+        )
 
     def test_update_dissimilarity_map_N3(self):
+        """Test the update function when there are only 3 subsets left. It
+        should return all zeros since the output is not used.
+        """
         # run to generate similarity map
-        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
+        self.snj_solver.get_dissimilarity_map(self.tree_pp)
         self.snj_solver.lambda_indices = [[0], [1, 2], [3, 4]]
         lambda_matrix_arr = self.snj_solver.compute_lambda(
             self.snj_solver.lambda_indices
-            )
-        
-        node_names = ['g1', 'g2', 'g3']
+        )
+
+        node_names = ["g1", "g2", "g3"]
         lambda_matrix = pd.DataFrame(
-            lambda_matrix_arr, 
-            index=node_names, 
-            columns=node_names
-            )
+            lambda_matrix_arr, index=node_names, columns=node_names
+        )
 
         node_i, node_j = (
-                lambda_matrix.index[0],
-                lambda_matrix.index[1],
-            )
-        
+            lambda_matrix.index[0],
+            lambda_matrix.index[1],
+        )
+
         svd2_vals = self.snj_solver.update_dissimilarity_map(
-            lambda_matrix,
-            (node_i, node_j),
-            'new_node'
+            lambda_matrix, (node_i, node_j), "new_node"
         )
 
         expected_lambda = np.zeros([2, 2])
 
         self.assertTrue(np.allclose(svd2_vals, expected_lambda, atol=0.1))
 
-    def test_get_dissimilarity_map(self): #todo: move to distancesolver test?
+    def test_get_dissimilarity_map(self):
+        """Test the override method that outputs a lambda matrix."""
+        # instantiate new solver
         new_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=False)
 
-        lambda_matrix = new_solver.get_dissimilarity_map(self.tree_general, None)
+        # get lambda products
+        lambda_matrix = new_solver.get_dissimilarity_map(
+            self.tree_general, None
+        )
         lambda_indices = new_solver.lambda_indices
-
-        expected_lambda_matrix = np.array([
-            [np.inf, 0.37210129, 0.3240793 , 0.13297122, 0.42458367],
-            [0.37210129, np.inf, 0.55367472, 0.39066669, 0.40739702],
-            [0.3240793 , 0.55367472, np.inf, 0.38248774, 0.24899081],
-            [0.13297122, 0.39066669, 0.38248774, np.inf, 0.53773514],
-            [0.42458367, 0.40739702, 0.24899081, 0.53773514, np.inf]
-            ])
-
         expected_lambda_indices = [[0], [1], [2], [3], [4]]
 
-        self.assertTrue(np.allclose(
-            lambda_matrix, 
-            expected_lambda_matrix, 
-            atol=0.1
-            ))
+        expected_lambda_matrix = np.array(
+            [
+                [
+                    np.inf,
+                    1.55149248e-01,
+                    1.53000011e-01,
+                    3.20069388e-01,
+                    3.25748925e-01,
+                ],
+                [
+                    1.55149248e-01,
+                    np.inf,
+                    4.14776245e-09,
+                    4.60567415e-01,
+                    4.59750019e-01,
+                ],
+                [
+                    1.53000011e-01,
+                    4.14776245e-09,
+                    np.inf,
+                    4.44601553e-01,
+                    4.57653025e-01,
+                ],
+                [
+                    3.20069388e-01,
+                    4.60567415e-01,
+                    4.44601553e-01,
+                    np.inf,
+                    4.45164957e-09,
+                ],
+                [
+                    3.25748925e-01,
+                    4.59750019e-01,
+                    4.57653025e-01,
+                    4.45164957e-09,
+                    np.inf,
+                ],
+            ]
+        )
 
-        self.assertTrue(np.allclose(
-            lambda_indices, 
-            expected_lambda_indices, 
-            atol=0
-            ))
-    
+        # get similarity matrices
+        obs_sim = new_solver._similarity_map
+        expected_sim = self.sim_general
+
+        # compare lambda matrix output
+        self.assertTrue(
+            np.allclose(lambda_matrix, expected_lambda_matrix, atol=0.1)
+        )
+
+        # compare similarity matrices
+        self.assertTrue(np.allclose(obs_sim, expected_sim, atol=0.1))
+
+        # compare indices
+        self.assertTrue(
+            np.allclose(lambda_indices, expected_lambda_indices, atol=0)
+        )
+
     def test_find_cherry(self):
-        fake_map1 = np.array([
-            [1, 1, 1, 0],
-            [1, 1, 1, 1],
-            [1, 1, 1, 1],
-            [0, 1, 1, 1],
-            ])
+        """Test the find_cherry method."""
+        fake_map1 = np.array(
+            [
+                [1, 1, 1, 0],
+                [1, 1, 1, 1],
+                [1, 1, 1, 1],
+                [0, 1, 1, 1],
+            ]
+        )
 
-        fake_map2 = np.array([
-            [1, 1, 1, 0],
-            [1, 1, 1, 0],
-            [1, 1, 1, 1],
-            [0, 0, 1, 1],
-            ])
+        fake_map2 = np.array(
+            [
+                [1, 1, 1, 0],
+                [1, 1, 1, 0],
+                [1, 1, 1, 1],
+                [0, 0, 1, 1],
+            ]
+        )
 
         cherry1 = self.snj_solver.find_cherry(fake_map1)
         cherry2 = self.snj_solver.find_cherry(fake_map2)
@@ -346,219 +483,229 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
         self.assertEqual(cherry2[0], 0)
         self.assertEqual(cherry2[1], 3)
 
+    def test_basic_solver(self):
+        """Test the features of the output of the solver on a root-specified input tree."""
+        self.snj_solver.solve(self.tree_general)
 
-    # def test_basic_solver(self):
+        # test leaves exist in tree
+        _leaves = self.tree_general.leaves
+        self.assertEqual(len(_leaves), self.sim_general.shape[0] - 1)
+        for _leaf in _leaves:
+            self.assertIn(_leaf, self.sim_general.index.values)
 
-    #     self.snj_solver.solve(self.tree_general)
+        # test for expected number of edges
+        edges = list(self.tree_general.edges)
+        self.assertEqual(len(edges), 6)
 
-    #     # test leaves exist in tree
-    #     _leaves = self.tree_general.leaves
+        # test relationships between samples
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("b", "c"),
+                ("b", "1"),
+                ("1", "a"),
+                ("1", "2"),
+                ("2", "d"),
+                ("2", "e"),
+            ]
+        )
 
-    #     self.assertEqual(
-    #         len(_leaves), self.sim_general.shape[0] - 1
-    #     )
-    #     for _leaf in _leaves:
-    #         self.assertIn(_leaf, self.sim_general.index.values)
+        # define leaf nodes.
+        leaves = ["a", "c", "d", "e"]
 
-    #     # test for expected number of edges
-    #     edges = list(self.tree_general.edges)
-    #     self.assertEqual(len(edges), 6)
+        # solve without collapsing mutationless edges
+        observed_tree = self.tree_general.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     # test relationships between samples
-    #     expected_tree = nx.DiGraph()
-    #     expected_tree.add_edges_from(
-    #         [
-    #             ("5", "a"),
-    #             ("5", "e"),
-    #             ("6", "5"),
-    #             ("b", "6"),
-    #             ("6", "7"),
-    #             ("7", "d"),
-    #             ("7", "c"),
-    #         ]
-    #     )
+        # solve with collapsing mutationless edges
+        self.snj_solver.solve(
+            self.tree_general, collapse_mutationless_edges=True
+        )
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(["a", "b", "c", "d", "e", "5", "6", "7"])
+        expected_tree.add_edges_from(
+            [("6", "a"), ("6", "e"), ("b", "6"), ("6", "d"), ("6", "c")]
+        )
+        observed_tree = self.tree_general.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     observed_tree = self.tree_general.get_tree_topology()
-    #     triplets = itertools.combinations(["a", "c", "d", "e"], 3)
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+        # compare tree distances
+        observed_tree = observed_tree.to_undirected()
+        expected_tree = expected_tree.to_undirected()
+        for i in range(len(_leaves)):
+            sample1 = _leaves[i]
+            for j in range(i + 1, len(_leaves)):
+                sample2 = _leaves[j]
+                self.assertEqual(
+                    nx.shortest_path_length(observed_tree, sample1, sample2),
+                    nx.shortest_path_length(expected_tree, sample1, sample2),
+                )
 
-    #     self.snj_solver.solve(self.tree_general, collapse_mutationless_edges=True)
-    #     expected_tree = nx.DiGraph()
-    #     expected_tree.add_nodes_from(["a", "b", "c", "d", "e", "5", "6", "7"])
-    #     expected_tree.add_edges_from(
-    #         [("6", "a"), ("6", "e"), ("b", "6"), ("6", "d"), ("6", "c")]
-    #     )
-    #     observed_tree = self.tree_general.get_tree_topology()
-    #     triplets = itertools.combinations(["a", "c", "d", "e"], 3)
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+    def test_snj_solver_weights(self):
+        """Test a perfect phylogenetic tree with priors."""
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "7"),
+                ("7", "6"),
+                ("6", "d"),
+                ("6", "e"),
+                ("7", "8"),
+                ("8", "a"),
+                ("8", "9"),
+                ("9", "b"),
+                ("9", "c"),
+            ]
+        )
 
-    #     # compare tree distances
-    #     observed_tree = observed_tree.to_undirected()
-    #     expected_tree = expected_tree.to_undirected()
-    #     for i in range(len(_leaves)):
-    #         sample1 = _leaves[i]
-    #         for j in range(i + 1, len(_leaves)):
-    #             sample2 = _leaves[j]
-    #             self.assertEqual(
-    #                 nx.shortest_path_length(observed_tree, sample1, sample2),
-    #                 nx.shortest_path_length(expected_tree, sample1, sample2),
-    #             )
+        leaves = ["a", "b", "c", "d", "e"]
 
-    # def test_snj_solver_weights(self):
-    #     self.snj_solver.solve(self.pp_tree_priors)
-    #     observed_tree = self.pp_tree_priors.get_tree_topology()
+        # solve without collapsing mutationless edges
+        self.snj_solver.solve(self.tree_pp_priors)
+        observed_tree = self.tree_pp_priors.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     expected_tree = nx.DiGraph()
-    #     expected_tree.add_edges_from(
-    #         [
-    #             ("root", "7"),
-    #             ("7", "6"),
-    #             ("6", "d"),
-    #             ("6", "e"),
-    #             ("7", "8"),
-    #             ("8", "a"),
-    #             ("8", "9"),
-    #             ("9", "b"),
-    #             ("9", "c"),
-    #         ]
-    #     )
+        # solve with collapsing mutationless edges
+        self.snj_solver.solve(
+            self.tree_pp_priors, collapse_mutationless_edges=True
+        )
+        observed_tree = self.tree_pp_priors.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+    def test_pp_solver(self):
+        """Integration Test for a Perfect Phylogenetic tree."""
+        # define expected tree
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "9"),
+                ("9", "8"),
+                ("9", "7"),
+                ("7", "6"),
+                ("7", "a"),
+                ("6", "b"),
+                ("6", "c"),
+                ("8", "e"),
+                ("8", "d"),
+            ]
+        )
 
-    #     self.snj_solver.solve(
-    #         self.pp_tree_priors, collapse_mutationless_edges=True
-    #     )
-    #     observed_tree = self.pp_tree_priors.get_tree_topology()
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+        # get all triplets
+        leaves = ["a", "b", "c", "d", "e"]
 
-    # def test_pp_solver(self):
+        # no collapsing mutationless edges
+        self.snj_solver.solve(self.tree_pp)
+        observed_tree = self.tree_pp.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     self.snj_solver_delta.solve(self.pp_tree)
-    #     observed_tree = self.pp_tree.get_tree_topology()
+        # collapse mutationless edges
+        self.snj_solver.solve(self.tree_pp, collapse_mutationless_edges=True)
+        observed_tree = self.tree_pp.get_tree_topology()
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
-    #     expected_tree = nx.DiGraph()
-    #     expected_tree.add_edges_from(
-    #         [
-    #             ("root", "9"),
-    #             ("9", "8"),
-    #             ("9", "7"),
-    #             ("7", "6"),
-    #             ("7", "a"),
-    #             ("6", "b"),
-    #             ("6", "c"),
-    #             ("8", "e"),
-    #             ("8", "d"),
-    #         ]
-    #     )
+    def test_duplicate_sample(self):
+        """Test the solving of a tree with duplicate leaves."""
 
-    #     triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+        self.snj_solver.solve(self.tree_dupe)
+        observed_tree = self.tree_dupe.get_tree_topology()
 
-    #     self.snj_solver_delta.solve(
-    #         self.pp_tree, collapse_mutationless_edges=True
-    #     )
-    #     observed_tree = self.pp_tree.get_tree_topology()
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "9"),
+                ("9", "8"),
+                ("9", "7"),
+                ("7", "6"),
+                ("7", "a"),
+                ("6", "b"),
+                ("6", "c"),
+                ("8", "10"),
+                ("10", "e"),
+                ("10", "f"),
+                ("8", "d"),
+            ]
+        )
 
-    # def test_duplicate_sample_neighbor_joining(self):
-
-    #     self.snj_solver_delta.solve(self.duplicate_tree)
-    #     observed_tree = self.duplicate_tree.get_tree_topology()
-
-    #     expected_tree = nx.DiGraph()
-    #     expected_tree.add_edges_from(
-    #         [
-    #             ("root", "9"),
-    #             ("9", "8"),
-    #             ("9", "7"),
-    #             ("7", "6"),
-    #             ("7", "a"),
-    #             ("6", "b"),
-    #             ("6", "c"),
-    #             ("8", "10"),
-    #             ("10", "e"),
-    #             ("10", "f"),
-    #             ("8", "d"),
-    #         ]
-    #     )
-
-    #     triplets = itertools.combinations(["a", "b", "c", "d", "e", "f"], 3)
-    #     for triplet in triplets:
-    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
-    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
-    #         self.assertEqual(expected_triplet, observed_triplet)
-
+        leaves = ["a", "b", "c", "d", "e", "f"]
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
     def test_integration1(self):
-        self.snj_solver.solve(self.itree_a)
-        expected_tree1 = nx.DiGraph()
-        expected_tree1.add_nodes_from(["a", "b", "c", "d", "e", "f", "g", "i1", "i2", "i3", "i4", "i5", "i6"])
-        expected_tree1.add_edges_from (
-                [
-                    ("i4", "i2"),
-                    ("i2", "d"),
-                    ("i2", "i1"), 
-                    ("i1", "a"),
-                    ("i1", "i3"),
-                    ("i3", "b"),
-                    ("i3", "c"),
-                    ("i4", "i5"),
-                    ("i5", "e"),
-                    ("i5", "i6"),
-                    ("i6", "f"),
-                    ("i6", "g")
-                ]
+        """Integration test on a 7-leaf tree."""
+
+        # construct expected tree
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
+            [
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+                "g",
+                "i1",
+                "i2",
+                "i3",
+                "i4",
+                "i5",
+                "i6",
+            ]
         )
-            
-        triplets = itertools.combinations(["a", "b", "c", "d", "e", "f", "g"], 3)
-        
-        observed_tree1 = self.itree_a.get_tree_topology()
+        expected_tree.add_edges_from(
+            [
+                ("i4", "i2"),
+                ("i2", "d"),
+                ("i2", "i1"),
+                ("i1", "a"),
+                ("i1", "i3"),
+                ("i3", "b"),
+                ("i3", "c"),
+                ("i4", "i5"),
+                ("i5", "e"),
+                ("i5", "i6"),
+                ("i6", "f"),
+                ("i6", "g"),
+            ]
+        )
 
-        nx.draw(observed_tree1, with_labels = True)
-        plt.savefig("test1_observed.pdf")
-        plt.clf()
+        # solve the tree
+        self.snj_solver.solve(self.tree_int1)
+        observed_tree = self.tree_int1.get_tree_topology()
 
-        nx.draw(observed_tree1, with_labels = False)
-        plt.savefig("test1_observed_nolabels.pdf")
-        plt.clf()
-
-        nx.draw(expected_tree1, with_labels = True)
-        plt.savefig("test1_expected.pdf")
-        plt.clf()
-
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree1)
-            observed_triplet = find_triplet_structure(triplet, observed_tree1)
-            self.assertEqual(expected_triplet, observed_triplet)
-
+        # check expected vs observed trees
+        leaves = ["a", "b", "c", "d", "e", "f", "g"]
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
     def test_integration2(self):
-        self.snj_solver.solve(self.itree_b)
-        expected_tree2 = nx.DiGraph()
-        
-        expected_tree2.add_nodes_from(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "i1", "i2", "i3", "i4", "i5", "i6", "i7", "i8", "i9"])
-        expected_tree2.add_edges_from (
+        """Integration test on a 10-leaf tree."""
+        # construct expected tree
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(
             [
-                ("i1", "i2"), 
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+                "g",
+                "h",
+                "i",
+                "j",
+                "i1",
+                "i2",
+                "i3",
+                "i4",
+                "i5",
+                "i6",
+                "i7",
+                "i8",
+                "i9",
+            ]
+        )
+        expected_tree.add_edges_from(
+            [
+                ("i1", "i2"),
                 ("i2", "e"),
                 ("i2", "i3"),
                 ("i3", "d"),
@@ -575,67 +722,46 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
                 ("i8", "h"),
                 ("i8", "i9"),
                 ("i9", "f"),
-                ("i9", "g")
+                ("i9", "g"),
             ]
         )
 
-        
-        triplets = itertools.combinations(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"], 3)
-        
-        observed_tree2 = self.itree_b.get_tree_topology()
+        # solve the tree
+        self.snj_solver.solve(self.tree_int2)
+        observed_tree = self.tree_int2.get_tree_topology()
 
-        nx.draw(observed_tree2, with_labels = True)
-        plt.savefig("test2_observed.pdf")
-        plt.clf()
-
-        nx.draw(observed_tree2, with_labels = False)
-        plt.savefig("test2_observed_nolabels.pdf")
-        plt.clf()
-
-        nx.draw(expected_tree2, with_labels = True)
-        plt.savefig("test2_expected.pdf")
-        plt.clf()
-
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree2)
-            observed_triplet = find_triplet_structure(triplet, observed_tree2)
-            self.assertEqual(expected_triplet, observed_triplet)
+        # check expected vs observed tree
+        leaves = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        assertTripletCorrectness(self, leaves, expected_tree, observed_tree)
 
     def test_setup_root_finder_missing_dissimilarity_map(self):
+        """Check that root still set despite missing dissimilarity map."""
         tree = cas.data.CassiopeiaTree(character_matrix=self.cm_general)
 
         self.snj_solver.setup_root_finder(tree)
 
         self.assertEqual(tree.root_sample_name, "root")
-        
-    # def test_setup_root_finder_existing_dissimilarity_map(self):
-    #     tree = cas.data.CassiopeiaTree(
-    #         character_matrix=self.cm,
-    #         dissimilarity_map=self.sim_general,
-    #     )
-    #     with mock.patch.object(
-    #         tree, "compute_dissimilarity_map"
-    #     ) as compute_dissimilarity_map:
-    #         self.snj_solver_delta.setup_root_finder(tree)
-    #         compute_dissimilarity_map.assert_not_called()
-    #     self.assertEqual(tree.root_sample_name, "root")
-    #     dissimilarity_map = tree.get_dissimilarity_map()
-    #     self.assertEqual(
-    #         {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.index)
-    #     )
-    #     self.assertEqual(
-    #         {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.columns)
-    #     )
-    #     for leaf in self.cm.index:
-    #         delta = delta_fn(
-    #             np.array([0] * tree.n_character),
-    #             self.cm.loc[leaf].values,
-    #             tree.missing_state_indicator,
-    #             None,
-    #         )
-    #         self.assertEqual(dissimilarity_map.loc[leaf, "root"], delta)
-    #         self.assertEqual(dissimilarity_map.loc["root", leaf], delta)
-    #     self.assertEqual(dissimilarity_map.loc["root", "root"], 0)
+
+    def test_setup_root_finder_existing_dissimilarity_map(self):
+        """Check that root is still set with existing dissimilarity map."""
+        tree = cas.data.CassiopeiaTree(
+            character_matrix=self.cm_general,
+            dissimilarity_map=self.sim_general,
+        )
+        with mock.patch.object(
+            tree, "compute_dissimilarity_map"
+        ) as compute_dissimilarity_map:
+            self.snj_solver.setup_root_finder(tree)
+            compute_dissimilarity_map.assert_not_called()
+        self.assertEqual(tree.root_sample_name, "root")
+        dissimilarity_map = tree.get_dissimilarity_map()
+        self.assertEqual(
+            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.index)
+        )
+        self.assertEqual(
+            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.columns)
+        )
+        self.assertEqual(dissimilarity_map.loc["root", "root"], 0)
 
 
 if __name__ == "__main__":

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -44,7 +44,8 @@ def find_triplet_structure(triplet, T):
 def assertTripletCorrectness(
     self, nodes: List[str], expected_tree: DiGraph, observed_tree: DiGraph
 ):
-    """Checks whether two trees are identical regardless of internal node names.
+    """Checks whether two trees are identical regardless of internal node
+    names.
 
     Args:
         nodes (List[str]): List of leaf nodes to get triplets from.
@@ -181,7 +182,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
         self.assertIsNotNone(self.tree_general.get_dissimilarity_map())
 
         nothing_solver = cas.solver.SpectralNeighborJoiningSolver(
-            dissimilarity_function=None, add_root=False
+            similarity_function=None, add_root=False
         )
 
         no_root_tree = cas.data.CassiopeiaTree(
@@ -193,7 +194,7 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             nothing_solver.solve(no_root_tree)
 
         no_root_solver = cas.solver.SpectralNeighborJoiningSolver(
-            dissimilarity_function=None, add_root=True
+            similarity_function=None, add_root=True
         )
 
         with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError):
@@ -502,7 +503,9 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
         self.assertEqual(cherry2[1], 3)
 
     def test_basic_solver(self):
-        """Test the features of the output of the solver on a root-specified input tree."""
+        """Test the features of the output of the solver on a root-specified
+        input tree.
+        """
         self.snj_solver.solve(self.tree_general)
 
         # test leaves exist in tree

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -1,0 +1,431 @@
+"""
+Test SpectralNeighborJoiningSolver in Cassiopeia.solver.
+"""
+import unittest
+from typing import Dict, Optional
+from unittest import mock
+
+import itertools
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+# Only for debugging purposes
+if True:
+    import sys
+    sys.path.insert(0, '../..')
+
+import cassiopeia as cas
+
+def find_triplet_structure(triplet, T):
+    a, b, c = triplet[0], triplet[1], triplet[2]
+    a_ancestors = [node for node in nx.ancestors(T, a)]
+    b_ancestors = [node for node in nx.ancestors(T, b)]
+    c_ancestors = [node for node in nx.ancestors(T, c)]
+    ab_common = len(set(a_ancestors) & set(b_ancestors))
+    ac_common = len(set(a_ancestors) & set(c_ancestors))
+    bc_common = len(set(b_ancestors) & set(c_ancestors))
+    structure = "-"
+    if ab_common > bc_common and ab_common > ac_common:
+        structure = "ab"
+    elif ac_common > bc_common and ac_common > ab_common:
+        structure = "ac"
+    elif bc_common > ab_common and bc_common > ac_common:
+        structure = "bc"
+    return structure
+
+
+# specify dissimilarity function for solvers to use
+def delta_fn(
+    x: np.ndarray,
+    y: np.ndarray,
+    missing_state: int,
+    priors: Optional[Dict[int, Dict[int, float]]],
+):
+    d = 0
+    for i in range(len(x)):
+        if x[i] != y[i]:
+            d += 1
+    return d
+
+
+class TestSpectralNeighborJoiningSolver(unittest.TestCase):
+    def setUp(self):
+
+        # --------------------- General NJ ---------------------
+        cm = pd.DataFrame.from_dict(
+            {
+                "a": [0, 1, 2],
+                "b": [1, 1, 2],
+                "c": [2, 2, 2],
+                "d": [1, 1, 1],
+                "e": [0, 0, 0],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        delta = pd.DataFrame.from_dict(
+            {
+                "a": [0, 15, 21, 17, 12],
+                "b": [15, 0, 10, 6, 17],
+                "c": [21, 10, 0, 10, 23],
+                "d": [17, 6, 10, 0, 19],
+                "e": [12, 17, 23, 19, 0],
+            },
+            orient="index",
+            columns=["a", "b", "c", "d", "e"],
+        )
+
+        self.cm = cm
+        self.basic_dissimilarity_map = delta
+        self.basic_tree = cas.data.CassiopeiaTree(
+            character_matrix=cm, dissimilarity_map=delta, root_sample_name="b"
+        )
+
+        self.nj_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=True)
+
+        # ---------------- Lineage Tracing NJ ----------------
+
+        pp_cm = pd.DataFrame.from_dict(
+            {
+                "a": [1, 1, 0],
+                "b": [1, 2, 0],
+                "c": [1, 2, 1],
+                "d": [2, 0, 0],
+                "e": [2, 0, 2],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        self.pp_tree = cas.data.CassiopeiaTree(character_matrix=pp_cm)
+
+        self.nj_solver_delta = cas.solver.SpectralNeighborJoiningSolver(
+            dissimilarity_function=delta_fn, add_root=True # type: ignore
+        )
+
+        # ------------- CM with Duplictes -----------------------
+        duplicates_cm = pd.DataFrame.from_dict(
+            {
+                "a": [1, 1, 0],
+                "b": [1, 2, 0],
+                "c": [1, 2, 1],
+                "d": [2, 0, 0],
+                "e": [2, 0, 2],
+                "f": [2, 0, 2],
+            },
+            orient="index",
+            columns=["x1", "x2", "x3"],
+        )
+
+        self.duplicate_tree = cas.data.CassiopeiaTree(
+            character_matrix=duplicates_cm
+        )
+
+        # ------------- NJ with modified hamming dissimilarity ------------
+        priors = {0: {1: 0.5, 2: 0.5}, 1: {1: 0.2, 2: 0.8}, 2: {1: 0.3, 2: 0.7}}
+        self.pp_tree_priors = cas.data.CassiopeiaTree(
+            character_matrix=pp_cm, priors=priors
+        )
+        self.nj_solver_modified = cas.solver.SpectralNeighborJoiningSolver(
+            dissimilarity_function=cas.solver.dissimilarity.weighted_hamming_distance, # type: ignore
+            add_root=True,
+        )
+
+    def test_constructor(self):
+        self.assertIsNotNone(self.nj_solver_delta.dissimilarity_function)
+        self.assertIsNotNone(self.basic_tree.get_dissimilarity_map())
+
+        nothing_solver = cas.solver.SpectralNeighborJoiningSolver(
+            dissimilarity_function=None, add_root=False
+        )
+
+        no_root_tree = cas.data.CassiopeiaTree(
+            character_matrix=self.cm,
+            dissimilarity_map=self.basic_dissimilarity_map,
+        )
+
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+            nothing_solver.solve(no_root_tree)
+
+        no_root_solver = cas.solver.SpectralNeighborJoiningSolver(
+            dissimilarity_function=None, add_root=True
+        )
+
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+            no_root_solver.solve(no_root_tree)
+
+        root_only_tree = cas.data.CassiopeiaTree(
+            character_matrix=self.cm, root_sample_name="b"
+        )
+
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+            nothing_solver.solve(root_only_tree)
+
+        nj_solver_fn = cas.solver.SpectralNeighborJoiningSolver(
+            add_root=True, dissimilarity_function=delta_fn  # type: ignore
+        ) 
+        nj_solver_fn.solve(self.basic_tree)
+
+        self.assertEqual(
+            self.basic_tree.get_dissimilarity_map().loc["a", "b"], 15
+        )
+
+    # def test_compute_q(self):
+    #     q_vals = self.nj_solver.compute_q(self.basic_dissimilarity_map.values)
+
+    #     expected_q = pd.DataFrame.from_dict(
+    #         {
+    #             "state0": [0, -22.67, -22, -22, -33.33],
+    #             "state1": [-22.67, 0, -27.33, -27.33, -22.67],
+    #             "state2": [-22, -27.33, 0, -28.67, -22],
+    #             "state3": [-22, -27.33, -28.67, 0, -22],
+    #             "state4": [-33.33, -22.67, -22, -22, 0],
+    #         },
+    #         orient="index",
+    #         columns=["state0", "state2", "state3", "state4", "state5"],
+    #     )
+
+    #     self.assertTrue(np.allclose(q_vals, expected_q, atol=0.1))
+
+    def test_find_cherry(self):
+
+        cherry = self.nj_solver.find_cherry(self.basic_dissimilarity_map.values)
+        delta = self.basic_dissimilarity_map
+        node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+
+        self.assertIn((node_i, node_j), [("a", "e"), ("e", "a")])
+
+    # def test_update_dissimilarity_map(self):
+
+    #     delta = self.basic_dissimilarity_map
+
+    #     cherry = self.nj_solver.find_cherry(delta.values)
+    #     node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+
+    #     delta = self.nj_solver.update_dissimilarity_map(
+    #         delta, (node_i, node_j), "f"
+    #     )
+
+    #     expected_delta = pd.DataFrame.from_dict(
+    #         {
+    #             "f": [0, 10, 16, 12],
+    #             "b": [10, 0, 10, 6],
+    #             "c": [16, 10, 0, 10],
+    #             "d": [12, 6, 10, 0],
+    #         },
+    #         orient="index",
+    #         columns=["f", "b", "c", "d"],
+    #     )
+
+    #     for sample in expected_delta.index:
+    #         for sample2 in expected_delta.index:
+    #             self.assertEqual(
+    #                 delta.loc[sample, sample2],
+    #                 expected_delta.loc[sample, sample2],
+    #             )
+
+    def test_basic_solver(self):
+
+        self.nj_solver.solve(self.basic_tree)
+
+        # test leaves exist in tree
+        _leaves = self.basic_tree.leaves
+
+        self.assertEqual(
+            len(_leaves), self.basic_dissimilarity_map.shape[0] - 1
+        )
+        for _leaf in _leaves:
+            self.assertIn(_leaf, self.basic_dissimilarity_map.index.values)
+
+        # test for expected number of edges
+        edges = list(self.basic_tree.edges)
+        self.assertEqual(len(edges), 6)
+
+        # test relationships between samples
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("5", "a"),
+                ("5", "e"),
+                ("6", "5"),
+                ("b", "6"),
+                ("6", "7"),
+                ("7", "d"),
+                ("7", "c"),
+            ]
+        )
+
+        observed_tree = self.basic_tree.get_tree_topology()
+        triplets = itertools.combinations(["a", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+        self.nj_solver.solve(self.basic_tree, collapse_mutationless_edges=True)
+        expected_tree = nx.DiGraph()
+        expected_tree.add_nodes_from(["a", "b", "c", "d", "e", "5", "6", "7"])
+        expected_tree.add_edges_from(
+            [("6", "a"), ("6", "e"), ("b", "6"), ("6", "d"), ("6", "c")]
+        )
+        observed_tree = self.basic_tree.get_tree_topology()
+        triplets = itertools.combinations(["a", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+        # compare tree distances
+        observed_tree = observed_tree.to_undirected()
+        expected_tree = expected_tree.to_undirected()
+        for i in range(len(_leaves)):
+            sample1 = _leaves[i]
+            for j in range(i + 1, len(_leaves)):
+                sample2 = _leaves[j]
+                self.assertEqual(
+                    nx.shortest_path_length(observed_tree, sample1, sample2),
+                    nx.shortest_path_length(expected_tree, sample1, sample2),
+                )
+
+    def test_nj_solver_weights(self):
+        self.nj_solver_modified.solve(self.pp_tree_priors)
+        observed_tree = self.pp_tree_priors.get_tree_topology()
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "7"),
+                ("7", "6"),
+                ("6", "d"),
+                ("6", "e"),
+                ("7", "8"),
+                ("8", "a"),
+                ("8", "9"),
+                ("9", "b"),
+                ("9", "c"),
+            ]
+        )
+
+        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+        self.nj_solver_modified.solve(
+            self.pp_tree_priors, collapse_mutationless_edges=True
+        )
+        observed_tree = self.pp_tree_priors.get_tree_topology()
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+    def test_pp_solver(self):
+
+        self.nj_solver_delta.solve(self.pp_tree)
+        observed_tree = self.pp_tree.get_tree_topology()
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "9"),
+                ("9", "8"),
+                ("9", "7"),
+                ("7", "6"),
+                ("7", "a"),
+                ("6", "b"),
+                ("6", "c"),
+                ("8", "e"),
+                ("8", "d"),
+            ]
+        )
+
+        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+        self.nj_solver_delta.solve(
+            self.pp_tree, collapse_mutationless_edges=True
+        )
+        observed_tree = self.pp_tree.get_tree_topology()
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+    def test_duplicate_sample_neighbor_joining(self):
+
+        self.nj_solver_delta.solve(self.duplicate_tree)
+        observed_tree = self.duplicate_tree.get_tree_topology()
+
+        expected_tree = nx.DiGraph()
+        expected_tree.add_edges_from(
+            [
+                ("root", "9"),
+                ("9", "8"),
+                ("9", "7"),
+                ("7", "6"),
+                ("7", "a"),
+                ("6", "b"),
+                ("6", "c"),
+                ("8", "10"),
+                ("10", "e"),
+                ("10", "f"),
+                ("8", "d"),
+            ]
+        )
+
+        triplets = itertools.combinations(["a", "b", "c", "d", "e", "f"], 3)
+        for triplet in triplets:
+            expected_triplet = find_triplet_structure(triplet, expected_tree)
+            observed_triplet = find_triplet_structure(triplet, observed_tree)
+            self.assertEqual(expected_triplet, observed_triplet)
+
+    def test_setup_root_finder_missing_dissimilarity_map(self):
+        tree = cas.data.CassiopeiaTree(character_matrix=self.cm)
+        with mock.patch.object(
+            tree, "compute_dissimilarity_map"
+        ) as compute_dissimilarity_map:
+            self.nj_solver_delta.setup_root_finder(tree)
+            compute_dissimilarity_map.assert_called_once_with(
+                delta_fn, "negative_log"
+            )
+        self.assertEqual(tree.root_sample_name, "root")
+
+    def test_setup_root_finder_existing_dissimilarity_map(self):
+        tree = cas.data.CassiopeiaTree(
+            character_matrix=self.cm,
+            dissimilarity_map=self.basic_dissimilarity_map,
+        )
+        with mock.patch.object(
+            tree, "compute_dissimilarity_map"
+        ) as compute_dissimilarity_map:
+            self.nj_solver_delta.setup_root_finder(tree)
+            compute_dissimilarity_map.assert_not_called()
+        self.assertEqual(tree.root_sample_name, "root")
+        dissimilarity_map = tree.get_dissimilarity_map()
+        self.assertEqual(
+            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.index)
+        )
+        self.assertEqual(
+            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.columns)
+        )
+        for leaf in self.cm.index:
+            delta = delta_fn(
+                np.array([0] * tree.n_character),
+                self.cm.loc[leaf].values,
+                tree.missing_state_indicator,
+                None,
+            )
+            self.assertEqual(dissimilarity_map.loc[leaf, "root"], delta)
+            self.assertEqual(dissimilarity_map.loc["root", leaf], delta)
+        self.assertEqual(dissimilarity_map.loc["root", "root"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -10,12 +10,6 @@ from networkx.classes.digraph import DiGraph
 import numpy as np
 import pandas as pd
 
-# Only for debugging purposes
-if True:
-    import sys
-
-    sys.path.insert(0, "../..")
-
 import cassiopeia as cas
 
 

--- a/test/solver_tests/snj_solver_test.py
+++ b/test/solver_tests/snj_solver_test.py
@@ -8,14 +8,17 @@ from unittest import mock
 import itertools
 import networkx as nx
 import numpy as np
+from numpy.testing._private.utils import assert_equal
 import pandas as pd
 
+
 # Only for debugging purposes
-if True:
-    import sys
-    sys.path.insert(0, '../..')
+# if True:
+#     import sys
+#     sys.path.insert(0, '../..')
 
 import cassiopeia as cas
+from cassiopeia.solver.dissimilarity_functions import exponential_negative_hamming_distance
 
 def find_triplet_structure(triplet, T):
     a, b, c = triplet[0], triplet[1], triplet[2]
@@ -35,25 +38,12 @@ def find_triplet_structure(triplet, T):
     return structure
 
 
-# specify dissimilarity function for solvers to use
-def delta_fn(
-    x: np.ndarray,
-    y: np.ndarray,
-    missing_state: int,
-    priors: Optional[Dict[int, Dict[int, float]]],
-):
-    d = 0
-    for i in range(len(x)):
-        if x[i] != y[i]:
-            d += 1
-    return d
-
-
 class TestSpectralNeighborJoiningSolver(unittest.TestCase):
     def setUp(self):
+        self.snj_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=True)
 
-        # --------------------- General NJ ---------------------
-        cm = pd.DataFrame.from_dict(
+        # --------------------- General SNJ ---------------------
+        cm_general = pd.DataFrame.from_dict(
             {
                 "a": [0, 1, 2],
                 "b": [1, 1, 2],
@@ -65,29 +55,27 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["x1", "x2", "x3"],
         )
 
-        delta = pd.DataFrame.from_dict(
+        sim_general = pd.DataFrame.from_dict(
             {
-                "a": [0, 15, 21, 17, 12],
-                "b": [15, 0, 10, 6, 17],
-                "c": [21, 10, 0, 10, 23],
-                "d": [17, 6, 10, 0, 19],
-                "e": [12, 17, 23, 19, 0],
+                "a": [0.0, 1/3, 1.0, 1.0, 2/3],
+                "b": [1/3, 0.0, 4/3, 2/3, 1.0],
+                "c": [1.0, 4/3, 0.0, 2.0, 1.0],
+                "d": [1.0, 2/3, 2.0, 0.0, 1.0],
+                "e": [2/3, 1.0, 1.0, 1.0, 0.0],
             },
             orient="index",
             columns=["a", "b", "c", "d", "e"],
         )
 
-        self.cm = cm
-        self.basic_dissimilarity_map = delta
-        self.basic_tree = cas.data.CassiopeiaTree(
-            character_matrix=cm, dissimilarity_map=delta, root_sample_name="b"
+        self.cm_general = cm_general
+        self.sim_general = sim_general
+        self.tree_general = cas.data.CassiopeiaTree(
+            character_matrix=cm_general, dissimilarity_map=sim_general, root_sample_name="b"
         )
 
-        self.nj_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=True)
+        # ---------------- Lineage Tracing SNJ ----------------
 
-        # ---------------- Lineage Tracing NJ ----------------
-
-        pp_cm = pd.DataFrame.from_dict(
+        cm_lineage = pd.DataFrame.from_dict(
             {
                 "a": [1, 1, 0],
                 "b": [1, 2, 0],
@@ -99,14 +87,10 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["x1", "x2", "x3"],
         )
 
-        self.pp_tree = cas.data.CassiopeiaTree(character_matrix=pp_cm)
+        self.tree_lineage = cas.data.CassiopeiaTree(character_matrix=cm_lineage)
 
-        self.nj_solver_delta = cas.solver.SpectralNeighborJoiningSolver(
-            dissimilarity_function=delta_fn, add_root=True # type: ignore
-        )
-
-        # ------------- CM with Duplictes -----------------------
-        duplicates_cm = pd.DataFrame.from_dict(
+        # ------------- CM with Duplicates -----------------------
+        cm_dupe = pd.DataFrame.from_dict(
             {
                 "a": [1, 1, 0],
                 "b": [1, 2, 0],
@@ -119,312 +103,408 @@ class TestSpectralNeighborJoiningSolver(unittest.TestCase):
             columns=["x1", "x2", "x3"],
         )
 
-        self.duplicate_tree = cas.data.CassiopeiaTree(
-            character_matrix=duplicates_cm
+        self.tree_dupe = cas.data.CassiopeiaTree(
+            character_matrix=cm_dupe
         )
 
-        # ------------- NJ with modified hamming dissimilarity ------------
+        # ------------- SNJ with modified hamming dissimilarity ------------
         priors = {0: {1: 0.5, 2: 0.5}, 1: {1: 0.2, 2: 0.8}, 2: {1: 0.3, 2: 0.7}}
-        self.pp_tree_priors = cas.data.CassiopeiaTree(
-            character_matrix=pp_cm, priors=priors
-        )
-        self.nj_solver_modified = cas.solver.SpectralNeighborJoiningSolver(
-            dissimilarity_function=cas.solver.dissimilarity.weighted_hamming_distance, # type: ignore
-            add_root=True,
+        self.tree_lineage_priors = cas.data.CassiopeiaTree(
+            character_matrix=cm_lineage, priors=priors
         )
 
     def test_constructor(self):
-        self.assertIsNotNone(self.nj_solver_delta.dissimilarity_function)
-        self.assertIsNotNone(self.basic_tree.get_dissimilarity_map())
+        self.assertIsNotNone(self.snj_solver.dissimilarity_function)
+        self.assertIsNotNone(self.tree_general.get_dissimilarity_map())
 
         nothing_solver = cas.solver.SpectralNeighborJoiningSolver(
             dissimilarity_function=None, add_root=False
         )
 
         no_root_tree = cas.data.CassiopeiaTree(
-            character_matrix=self.cm,
-            dissimilarity_map=self.basic_dissimilarity_map,
+            character_matrix=self.cm_general,
+            dissimilarity_map=self.sim_general,
         )
 
-        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError):
             nothing_solver.solve(no_root_tree)
 
         no_root_solver = cas.solver.SpectralNeighborJoiningSolver(
             dissimilarity_function=None, add_root=True
         )
 
-        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError):
             no_root_solver.solve(no_root_tree)
 
         root_only_tree = cas.data.CassiopeiaTree(
-            character_matrix=self.cm, root_sample_name="b"
+            character_matrix=self.cm_general, root_sample_name="b"
         )
 
-        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError): # type: ignore
+        with self.assertRaises(cas.solver.DistanceSolver.DistanceSolverError):
             nothing_solver.solve(root_only_tree)
 
-        nj_solver_fn = cas.solver.SpectralNeighborJoiningSolver(
-            add_root=True, dissimilarity_function=delta_fn  # type: ignore
+        snj_solver_fn = cas.solver.SpectralNeighborJoiningSolver(
+            add_root=True 
         ) 
-        nj_solver_fn.solve(self.basic_tree)
+        snj_solver_fn.solve(self.tree_general)
 
         self.assertEqual(
-            self.basic_tree.get_dissimilarity_map().loc["a", "b"], 15
+            self.tree_general.get_dissimilarity_map().loc["a", "b"], 1/3
         )
 
-    # def test_compute_q(self):
-    #     q_vals = self.nj_solver.compute_q(self.basic_dissimilarity_map.values)
+    def test_compute_lambda_pairwise(self):
+        self.lambda_pairwise = [[i] for i in range(self.sim_general.values.shape[0])]
 
-    #     expected_q = pd.DataFrame.from_dict(
-    #         {
-    #             "state0": [0, -22.67, -22, -22, -33.33],
-    #             "state1": [-22.67, 0, -27.33, -27.33, -22.67],
-    #             "state2": [-22, -27.33, 0, -28.67, -22],
-    #             "state3": [-22, -27.33, -28.67, 0, -22],
-    #             "state4": [-33.33, -22.67, -22, -22, 0],
-    #         },
-    #         orient="index",
-    #         columns=["state0", "state2", "state3", "state4", "state5"],
-    #     )
+        # run to generate similarity map
+        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
 
-    #     self.assertTrue(np.allclose(q_vals, expected_q, atol=0.1))
+        svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
 
+        expected_q = pd.DataFrame.from_dict(
+            {
+                "state0": [np.inf, 0.43661943, 0.31344894, 0.7780976 , 0.67849699],
+                "state1": [0.43661943, np.inf, 0.09190727, 1.01535639, 0.86536494],
+                "state2": [0.31344894, 0.09190727, np.inf, 0.95520247, 1.01083351],
+                "state3": [0.7780976 , 1.01535639, 0.95520247, np.inf, 0.04942259],
+                "state4": [0.67849699, 0.86536494, 1.01083351, 0.04942259, np.inf],
+            },
+            orient="index",
+            columns=["state0", "state2", "state3", "state4", "state5"],
+        )
+
+        self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
+
+    def test_compute_lambda_N3(self):
+        self.lambda_pairwise = [[0], [1, 2], [3, 4]]
+
+        # run to generate similarity map
+        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
+        
+        svd2_vals = self.snj_solver.compute_lambda(self.lambda_pairwise)
+
+        expected_q = np.array([
+            [np.inf, 0.04942259, 0.09190727],
+            [0.04942259, np.inf, 2.05480467],
+            [0.09190727, 2.05480467, np.inf]
+            ])
+
+        self.assertTrue(np.allclose(svd2_vals, expected_q, atol=0.1))
+
+    def test_update_dissimilarity_map_base(self):
+        # run to generate similarity map
+        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
+        self.snj_solver.lambda_indices = [[0], [1], [2], [3], [4]]
+        lambda_matrix_arr = self.snj_solver.compute_lambda(
+            self.snj_solver.lambda_indices
+            )
+        
+        node_names = self.sim_general.index
+        lambda_matrix = pd.DataFrame(
+            lambda_matrix_arr, 
+            index=node_names, 
+            columns=node_names
+            )
+
+        node_i, node_j = (
+                lambda_matrix.index[0],
+                lambda_matrix.index[1],
+            )
+        
+        svd2_vals = self.snj_solver.update_dissimilarity_map(
+            lambda_matrix,
+            (node_i, node_j),
+            'new_node'
+        )
+
+        expected_lambda = np.array([
+            [np.inf, 0.95520247, 1.01083351, 0.04942259],
+            [0.95520247, np.inf, 0.04942259, 1.01083351],
+            [1.01083351, 0.04942259, np.inf, 0.95520247],
+            [0.04942259, 1.01083351, 0.95520247, np.inf]
+       ])
+
+        self.assertTrue(np.allclose(svd2_vals, expected_lambda, atol=0.1))
+        self.assertListEqual(svd2_vals.index.values.tolist(), ['c', 'd', 'e', 'new_node'])
+        self.assertListEqual(svd2_vals.columns.values.tolist(), ['c', 'd', 'e', 'new_node'])
+
+    def test_update_dissimilarity_map_N3(self):
+        # run to generate similarity map
+        self.snj_solver.get_dissimilarity_map(self.tree_lineage)
+        self.snj_solver.lambda_indices = [[0], [1, 2], [3, 4]]
+        lambda_matrix_arr = self.snj_solver.compute_lambda(
+            self.snj_solver.lambda_indices
+            )
+        
+        node_names = ['g1', 'g2', 'g3']
+        lambda_matrix = pd.DataFrame(
+            lambda_matrix_arr, 
+            index=node_names, 
+            columns=node_names
+            )
+
+        node_i, node_j = (
+                lambda_matrix.index[0],
+                lambda_matrix.index[1],
+            )
+        
+        svd2_vals = self.snj_solver.update_dissimilarity_map(
+            lambda_matrix,
+            (node_i, node_j),
+            'new_node'
+        )
+
+        expected_lambda = np.zeros([2, 2])
+
+        self.assertTrue(np.allclose(svd2_vals, expected_lambda, atol=0.1))
+
+    def test_get_dissimilarity_map(self): #todo: move to distancesolver test?
+        new_solver = cas.solver.SpectralNeighborJoiningSolver(add_root=False)
+
+        lambda_matrix = new_solver.get_dissimilarity_map(self.tree_general, None)
+        lambda_indices = new_solver.lambda_indices
+
+        expected_lambda_matrix = np.array([
+            [np.inf, 0.37210129, 0.3240793 , 0.13297122, 0.42458367],
+            [0.37210129, np.inf, 0.55367472, 0.39066669, 0.40739702],
+            [0.3240793 , 0.55367472, np.inf, 0.38248774, 0.24899081],
+            [0.13297122, 0.39066669, 0.38248774, np.inf, 0.53773514],
+            [0.42458367, 0.40739702, 0.24899081, 0.53773514, np.inf]
+            ])
+
+        expected_lambda_indices = [[0], [1], [2], [3], [4]]
+
+        self.assertTrue(np.allclose(
+            lambda_matrix, 
+            expected_lambda_matrix, 
+            atol=0.1
+            ))
+
+        self.assertTrue(np.allclose(
+            lambda_indices, 
+            expected_lambda_indices, 
+            atol=0
+            ))
+    
     def test_find_cherry(self):
+        fake_map1 = np.array([
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [0, 1, 1, 1],
+            ])
 
-        cherry = self.nj_solver.find_cherry(self.basic_dissimilarity_map.values)
-        delta = self.basic_dissimilarity_map
-        node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+        fake_map2 = np.array([
+            [1, 1, 1, 0],
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+            [0, 0, 1, 1],
+            ])
 
-        self.assertIn((node_i, node_j), [("a", "e"), ("e", "a")])
+        cherry1 = self.snj_solver.find_cherry(fake_map1)
+        cherry2 = self.snj_solver.find_cherry(fake_map2)
 
-    # def test_update_dissimilarity_map(self):
+        self.assertEqual(len(cherry1), 2)
+        self.assertEqual(cherry1[0], 0)
+        self.assertEqual(cherry1[1], 3)
+        self.assertEqual(cherry2[0], 0)
+        self.assertEqual(cherry2[1], 3)
 
-    #     delta = self.basic_dissimilarity_map
 
-    #     cherry = self.nj_solver.find_cherry(delta.values)
-    #     node_i, node_j = (delta.index[cherry[0]], delta.index[cherry[1]])
+    # def test_basic_solver(self):
 
-    #     delta = self.nj_solver.update_dissimilarity_map(
-    #         delta, (node_i, node_j), "f"
+    #     self.snj_solver.solve(self.tree_general)
+
+    #     # test leaves exist in tree
+    #     _leaves = self.tree_general.leaves
+
+    #     self.assertEqual(
+    #         len(_leaves), self.sim_general.shape[0] - 1
+    #     )
+    #     for _leaf in _leaves:
+    #         self.assertIn(_leaf, self.sim_general.index.values)
+
+    #     # test for expected number of edges
+    #     edges = list(self.tree_general.edges)
+    #     self.assertEqual(len(edges), 6)
+
+    #     # test relationships between samples
+    #     expected_tree = nx.DiGraph()
+    #     expected_tree.add_edges_from(
+    #         [
+    #             ("5", "a"),
+    #             ("5", "e"),
+    #             ("6", "5"),
+    #             ("b", "6"),
+    #             ("6", "7"),
+    #             ("7", "d"),
+    #             ("7", "c"),
+    #         ]
     #     )
 
-    #     expected_delta = pd.DataFrame.from_dict(
-    #         {
-    #             "f": [0, 10, 16, 12],
-    #             "b": [10, 0, 10, 6],
-    #             "c": [16, 10, 0, 10],
-    #             "d": [12, 6, 10, 0],
-    #         },
-    #         orient="index",
-    #         columns=["f", "b", "c", "d"],
-    #     )
+    #     observed_tree = self.tree_general.get_tree_topology()
+    #     triplets = itertools.combinations(["a", "c", "d", "e"], 3)
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
-    #     for sample in expected_delta.index:
-    #         for sample2 in expected_delta.index:
+    #     self.snj_solver.solve(self.tree_general, collapse_mutationless_edges=True)
+    #     expected_tree = nx.DiGraph()
+    #     expected_tree.add_nodes_from(["a", "b", "c", "d", "e", "5", "6", "7"])
+    #     expected_tree.add_edges_from(
+    #         [("6", "a"), ("6", "e"), ("b", "6"), ("6", "d"), ("6", "c")]
+    #     )
+    #     observed_tree = self.tree_general.get_tree_topology()
+    #     triplets = itertools.combinations(["a", "c", "d", "e"], 3)
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
+
+    #     # compare tree distances
+    #     observed_tree = observed_tree.to_undirected()
+    #     expected_tree = expected_tree.to_undirected()
+    #     for i in range(len(_leaves)):
+    #         sample1 = _leaves[i]
+    #         for j in range(i + 1, len(_leaves)):
+    #             sample2 = _leaves[j]
     #             self.assertEqual(
-    #                 delta.loc[sample, sample2],
-    #                 expected_delta.loc[sample, sample2],
+    #                 nx.shortest_path_length(observed_tree, sample1, sample2),
+    #                 nx.shortest_path_length(expected_tree, sample1, sample2),
     #             )
 
-    def test_basic_solver(self):
+    # def test_snj_solver_weights(self):
+    #     self.snj_solver.solve(self.pp_tree_priors)
+    #     observed_tree = self.pp_tree_priors.get_tree_topology()
 
-        self.nj_solver.solve(self.basic_tree)
+    #     expected_tree = nx.DiGraph()
+    #     expected_tree.add_edges_from(
+    #         [
+    #             ("root", "7"),
+    #             ("7", "6"),
+    #             ("6", "d"),
+    #             ("6", "e"),
+    #             ("7", "8"),
+    #             ("8", "a"),
+    #             ("8", "9"),
+    #             ("9", "b"),
+    #             ("9", "c"),
+    #         ]
+    #     )
 
-        # test leaves exist in tree
-        _leaves = self.basic_tree.leaves
+    #     triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
-        self.assertEqual(
-            len(_leaves), self.basic_dissimilarity_map.shape[0] - 1
-        )
-        for _leaf in _leaves:
-            self.assertIn(_leaf, self.basic_dissimilarity_map.index.values)
+    #     self.snj_solver.solve(
+    #         self.pp_tree_priors, collapse_mutationless_edges=True
+    #     )
+    #     observed_tree = self.pp_tree_priors.get_tree_topology()
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
-        # test for expected number of edges
-        edges = list(self.basic_tree.edges)
-        self.assertEqual(len(edges), 6)
+    # def test_pp_solver(self):
 
-        # test relationships between samples
-        expected_tree = nx.DiGraph()
-        expected_tree.add_edges_from(
-            [
-                ("5", "a"),
-                ("5", "e"),
-                ("6", "5"),
-                ("b", "6"),
-                ("6", "7"),
-                ("7", "d"),
-                ("7", "c"),
-            ]
-        )
+    #     self.snj_solver_delta.solve(self.pp_tree)
+    #     observed_tree = self.pp_tree.get_tree_topology()
 
-        observed_tree = self.basic_tree.get_tree_topology()
-        triplets = itertools.combinations(["a", "c", "d", "e"], 3)
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
+    #     expected_tree = nx.DiGraph()
+    #     expected_tree.add_edges_from(
+    #         [
+    #             ("root", "9"),
+    #             ("9", "8"),
+    #             ("9", "7"),
+    #             ("7", "6"),
+    #             ("7", "a"),
+    #             ("6", "b"),
+    #             ("6", "c"),
+    #             ("8", "e"),
+    #             ("8", "d"),
+    #         ]
+    #     )
 
-        self.nj_solver.solve(self.basic_tree, collapse_mutationless_edges=True)
-        expected_tree = nx.DiGraph()
-        expected_tree.add_nodes_from(["a", "b", "c", "d", "e", "5", "6", "7"])
-        expected_tree.add_edges_from(
-            [("6", "a"), ("6", "e"), ("b", "6"), ("6", "d"), ("6", "c")]
-        )
-        observed_tree = self.basic_tree.get_tree_topology()
-        triplets = itertools.combinations(["a", "c", "d", "e"], 3)
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
+    #     triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
-        # compare tree distances
-        observed_tree = observed_tree.to_undirected()
-        expected_tree = expected_tree.to_undirected()
-        for i in range(len(_leaves)):
-            sample1 = _leaves[i]
-            for j in range(i + 1, len(_leaves)):
-                sample2 = _leaves[j]
-                self.assertEqual(
-                    nx.shortest_path_length(observed_tree, sample1, sample2),
-                    nx.shortest_path_length(expected_tree, sample1, sample2),
-                )
+    #     self.snj_solver_delta.solve(
+    #         self.pp_tree, collapse_mutationless_edges=True
+    #     )
+    #     observed_tree = self.pp_tree.get_tree_topology()
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
-    def test_nj_solver_weights(self):
-        self.nj_solver_modified.solve(self.pp_tree_priors)
-        observed_tree = self.pp_tree_priors.get_tree_topology()
+    # def test_duplicate_sample_neighbor_joining(self):
 
-        expected_tree = nx.DiGraph()
-        expected_tree.add_edges_from(
-            [
-                ("root", "7"),
-                ("7", "6"),
-                ("6", "d"),
-                ("6", "e"),
-                ("7", "8"),
-                ("8", "a"),
-                ("8", "9"),
-                ("9", "b"),
-                ("9", "c"),
-            ]
-        )
+    #     self.snj_solver_delta.solve(self.duplicate_tree)
+    #     observed_tree = self.duplicate_tree.get_tree_topology()
 
-        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
+    #     expected_tree = nx.DiGraph()
+    #     expected_tree.add_edges_from(
+    #         [
+    #             ("root", "9"),
+    #             ("9", "8"),
+    #             ("9", "7"),
+    #             ("7", "6"),
+    #             ("7", "a"),
+    #             ("6", "b"),
+    #             ("6", "c"),
+    #             ("8", "10"),
+    #             ("10", "e"),
+    #             ("10", "f"),
+    #             ("8", "d"),
+    #         ]
+    #     )
 
-        self.nj_solver_modified.solve(
-            self.pp_tree_priors, collapse_mutationless_edges=True
-        )
-        observed_tree = self.pp_tree_priors.get_tree_topology()
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
-
-    def test_pp_solver(self):
-
-        self.nj_solver_delta.solve(self.pp_tree)
-        observed_tree = self.pp_tree.get_tree_topology()
-
-        expected_tree = nx.DiGraph()
-        expected_tree.add_edges_from(
-            [
-                ("root", "9"),
-                ("9", "8"),
-                ("9", "7"),
-                ("7", "6"),
-                ("7", "a"),
-                ("6", "b"),
-                ("6", "c"),
-                ("8", "e"),
-                ("8", "d"),
-            ]
-        )
-
-        triplets = itertools.combinations(["a", "b", "c", "d", "e"], 3)
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
-
-        self.nj_solver_delta.solve(
-            self.pp_tree, collapse_mutationless_edges=True
-        )
-        observed_tree = self.pp_tree.get_tree_topology()
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
-
-    def test_duplicate_sample_neighbor_joining(self):
-
-        self.nj_solver_delta.solve(self.duplicate_tree)
-        observed_tree = self.duplicate_tree.get_tree_topology()
-
-        expected_tree = nx.DiGraph()
-        expected_tree.add_edges_from(
-            [
-                ("root", "9"),
-                ("9", "8"),
-                ("9", "7"),
-                ("7", "6"),
-                ("7", "a"),
-                ("6", "b"),
-                ("6", "c"),
-                ("8", "10"),
-                ("10", "e"),
-                ("10", "f"),
-                ("8", "d"),
-            ]
-        )
-
-        triplets = itertools.combinations(["a", "b", "c", "d", "e", "f"], 3)
-        for triplet in triplets:
-            expected_triplet = find_triplet_structure(triplet, expected_tree)
-            observed_triplet = find_triplet_structure(triplet, observed_tree)
-            self.assertEqual(expected_triplet, observed_triplet)
+    #     triplets = itertools.combinations(["a", "b", "c", "d", "e", "f"], 3)
+    #     for triplet in triplets:
+    #         expected_triplet = find_triplet_structure(triplet, expected_tree)
+    #         observed_triplet = find_triplet_structure(triplet, observed_tree)
+    #         self.assertEqual(expected_triplet, observed_triplet)
 
     def test_setup_root_finder_missing_dissimilarity_map(self):
-        tree = cas.data.CassiopeiaTree(character_matrix=self.cm)
-        with mock.patch.object(
-            tree, "compute_dissimilarity_map"
-        ) as compute_dissimilarity_map:
-            self.nj_solver_delta.setup_root_finder(tree)
-            compute_dissimilarity_map.assert_called_once_with(
-                delta_fn, "negative_log"
-            )
+        tree = cas.data.CassiopeiaTree(character_matrix=self.cm_general)
+
+        self.snj_solver.setup_root_finder(tree)
+
         self.assertEqual(tree.root_sample_name, "root")
 
-    def test_setup_root_finder_existing_dissimilarity_map(self):
-        tree = cas.data.CassiopeiaTree(
-            character_matrix=self.cm,
-            dissimilarity_map=self.basic_dissimilarity_map,
-        )
-        with mock.patch.object(
-            tree, "compute_dissimilarity_map"
-        ) as compute_dissimilarity_map:
-            self.nj_solver_delta.setup_root_finder(tree)
-            compute_dissimilarity_map.assert_not_called()
-        self.assertEqual(tree.root_sample_name, "root")
-        dissimilarity_map = tree.get_dissimilarity_map()
-        self.assertEqual(
-            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.index)
-        )
-        self.assertEqual(
-            {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.columns)
-        )
-        for leaf in self.cm.index:
-            delta = delta_fn(
-                np.array([0] * tree.n_character),
-                self.cm.loc[leaf].values,
-                tree.missing_state_indicator,
-                None,
-            )
-            self.assertEqual(dissimilarity_map.loc[leaf, "root"], delta)
-            self.assertEqual(dissimilarity_map.loc["root", leaf], delta)
-        self.assertEqual(dissimilarity_map.loc["root", "root"], 0)
+    # def test_setup_root_finder_existing_dissimilarity_map(self):
+    #     tree = cas.data.CassiopeiaTree(
+    #         character_matrix=self.cm,
+    #         dissimilarity_map=self.sim_general,
+    #     )
+    #     with mock.patch.object(
+    #         tree, "compute_dissimilarity_map"
+    #     ) as compute_dissimilarity_map:
+    #         self.snj_solver_delta.setup_root_finder(tree)
+    #         compute_dissimilarity_map.assert_not_called()
+    #     self.assertEqual(tree.root_sample_name, "root")
+    #     dissimilarity_map = tree.get_dissimilarity_map()
+    #     self.assertEqual(
+    #         {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.index)
+    #     )
+    #     self.assertEqual(
+    #         {"a", "b", "c", "d", "e", "root"}, set(dissimilarity_map.columns)
+    #     )
+    #     for leaf in self.cm.index:
+    #         delta = delta_fn(
+    #             np.array([0] * tree.n_character),
+    #             self.cm.loc[leaf].values,
+    #             tree.missing_state_indicator,
+    #             None,
+    #         )
+    #         self.assertEqual(dissimilarity_map.loc[leaf, "root"], delta)
+    #         self.assertEqual(dissimilarity_map.loc["root", leaf], delta)
+    #     self.assertEqual(dissimilarity_map.loc["root", "root"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**
Spectral Neighbor Joining algorithm (Jaffe 2020) implemented as a solver that implements DistanceSolver.

Also, an updated DistanceSolver method (get_dissimilarity_map) which replaces the same functionality previously done within solve(). This is to allow the use of alternative matrices besides the dissimilarity map in solve.

**Todos:**
- [ ] Add integration tests
- [ ] Ensure Black formatting and other stylistic guidelines

**Questions**
- What does add_root do in neighborjoining? It triggers setup root finder at the start (get dissimilarity map method), which adds another node called "root". What is this for? What about root_tree that's run after solve? Why root twice?
- What do we do with duplicate rows in a character matrix?