### PR TITLE
refactored how hybrid log files are created

### DIFF
--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -169,7 +169,7 @@ def upload_and_export_itol(
 
         if pd.api.types.is_string_dtype(values):
             colors = palette[: len(values.unique())]
-            colors = [hex_to_rgb(color) for color in colors]
+            colors = [utilities.hex_to_rgb(color) for color in colors]
             colormap = dict(zip(np.unique(values), colors))
 
             files.append(

--- a/cassiopeia/plotting/itol_utilities.py
+++ b/cassiopeia/plotting/itol_utilities.py
@@ -482,14 +482,9 @@ def create_indel_heatmap(
                 "",
             ]
 
-        if len(str(j)) == 1:
-            alleleLabel_fileout = os.path.join(
-                output_directory, f"indelColors_0{j}.txt"
-            )
-        elif len(str(j)) == 2:
-            alleleLabel_fileout = os.path.join(
-                output_directory, f"indelColors_{j}.txt"
-            )
+        alleleLabel_fileout = os.path.join(
+            output_directory, f"indelColors_0{str(j).zfill(4)}.txt")
+
         with open(alleleLabel_fileout, "w") as ALout:
             for line in header:
                 ALout.write(line + "\n")

--- a/cassiopeia/solver/HybridSolver.py
+++ b/cassiopeia/solver/HybridSolver.py
@@ -141,6 +141,8 @@ class HybridSolver(CassiopeiaSolver.CassiopeiaSolver):
             missing_state_indicator=cassiopeia_tree.missing_state_indicator,
         )
 
+        logfile_names = iter([i for i in range(1, len(subproblems) + 1)])
+
         # multi-threaded bottom solver approach
         with multiprocessing.Pool(processes=self.threads) as pool:
 
@@ -153,7 +155,8 @@ class HybridSolver(CassiopeiaSolver.CassiopeiaSolver):
                                 cassiopeia_tree,
                                 subproblem[0],
                                 subproblem[1],
-                                logfile,
+                                f"{logfile.split('.log')[0]}-"
+                                        f"{next(logfile_names)}.log",
                                 layer,
                             )
                             for subproblem in subproblems
@@ -266,7 +269,7 @@ class HybridSolver(CassiopeiaSolver.CassiopeiaSolver):
                 )
                 tree.add_edge(root, child)
 
-                subproblems += new_subproblems            
+                subproblems += new_subproblems
 
         return root, subproblems, tree
 
@@ -321,15 +324,12 @@ class HybridSolver(CassiopeiaSolver.CassiopeiaSolver):
             cassiopeia_tree.missing_state_indicator,
         )
 
-        base_logfile = logfile.split(".log")[0]
-        subtree_root_string = "-".join([str(s) for s in subtree_root])
-        logfile = f"{base_logfile}_{subtree_root_string}.log"
-
         subtree = CassiopeiaTree(
             subproblem_character_matrix,
             missing_state_indicator=cassiopeia_tree.missing_state_indicator,
             priors=cassiopeia_tree.priors,
         )
+
         self.bottom_solver.solve(subtree, logfile=logfile)
 
         subproblem_tree = subtree.get_tree_topology()

--- a/cassiopeia/solver/ILPSolver.py
+++ b/cassiopeia/solver/ILPSolver.py
@@ -163,6 +163,9 @@ class ILPSolver(CassiopeiaSolver.CassiopeiaSolver):
                 cassiopeia_tree.missing_state_indicator,
             )
         )
+
+        logger.info(f"Phylogenetic root: {root}")
+
         pid = hashlib.md5(
             "|".join([str(r) for r in root]).encode("utf-8")
         ).hexdigest()


### PR DESCRIPTION
This PR fixes an issue identified by a user that had ~150 characters in their data: in this case, this created logfiles for HybridSolvers that were too long for linux systems. This PR sets up a simple iterator for creating new logfiles, and stores the root of the subproblem within the log. 