### PR TITLE
Implement vectorized log-likelihood computation to speed up cvxpy.

### DIFF
--- a/cassiopeia/tools/branch_length_estimator/_iid_exponential_mle.py
+++ b/cassiopeia/tools/branch_length_estimator/_iid_exponential_mle.py
@@ -375,7 +375,7 @@ class IIDExponentialMLE(BranchLengthEstimator):
                 prob.solve(solver=backup_solver, verbose=verbose)
                 self._backup_solver_was_needed = True
             except cp.SolverError:  # pragma: no cover
-                raise IIDExponentialMLEError("Third-party solver failed")
+                raise IIDExponentialMLEError("Third-party solver(s) failed")
 
         # # # # # Extract the mutation rate # # # # #
         scaling_factor = float(t_variables[deepest_leaf].value)

--- a/cassiopeia/tools/branch_length_estimator/_iid_exponential_mle.py
+++ b/cassiopeia/tools/branch_length_estimator/_iid_exponential_mle.py
@@ -93,7 +93,7 @@ class IIDExponentialMLE(BranchLengthEstimator):
         relative_leaf_depth: Optional[List[Tuple[str, float]]] = None,
         relative_mutation_rates: Optional[List[float]] = None,
         verbose: bool = False,
-        solver: str = "SCS",
+        solver: str = "ECOS",
         _use_vectorized_implementation: bool = True,
     ):
         allowed_solvers = ["ECOS", "SCS", "MOSEK"]


### PR DESCRIPTION
As title.

With the new implementation, branch length estimation should be ~10-20x faster.

I have extended `IIDExponentialMLE`'s API with a private argument that toggles between the vectorized and non-vectorized implementations, to be able to profile the difference.

As I have observed in the past, the ECOS solver benefits the most from vectorization (SCS instead performs the same...). Because of this, I have decided to make the ECOS solver (with vectorization) the default one. In this sense, this PR is non-backwards compatible - since the default solver used to be SCS - but it's fine since out method has not been published yet. Unfortunately, the ECOS solver is not as stable as SCS and can sometimes fails (say 5% of the time). Because of this, I have extended the API of the branch length estimator to include a `backup_solver`. If the main `solver` fails, we retry with the backup solver. With the new API's default arguments, the main solver is ECOS, and if it fails, the slower but reliable SCS solver will be used.

NOTE: switching to the ECOS solver on its own speeds up the branch length estimator by ~7x, the remaining ~2-3x being provided by vectorization. The reason I did not use ECOS originally is because SCS is extremely robust; however, we want something faster for dealing with site rate variation now, so the new scheme of ECOS + fallback to SCS should be awesome.

Test plan:
- All old tests pass.
- The following code snippet profiles branch length estimation on a tree with 512 leaves, using either SCS or ECOS, and a vectorized or non-vectorized implementation (for a total of 4 combinations):
```
import time

from cassiopeia.simulator import CompleteBinarySimulator, Cas9LineageTracingDataSimulator
from cassiopeia.tools.branch_length_estimator import IIDExponentialMLE

tree = CompleteBinarySimulator(num_cells=512).simulate_tree()
Cas9LineageTracingDataSimulator(mutation_rate=1.0, random_seed=0).overlay_data(tree)
for solver in ["SCS", "ECOS"]:
    for _use_vectorized_implementation in [False, True]:
        st = time.time()
        IIDExponentialMLE(
            minimum_branch_length=0.01,
            pseudo_mutations_per_edge=0.1,
            pseudo_non_mutations_per_edge=0.1,
            solver=solver,
            _use_vectorized_implementation=_use_vectorized_implementation,
        ).estimate_branch_lengths(tree)
        et = time.time()
        msg_str= f"Time using solver {solver} and _use_vectorized_implementation={_use_vectorized_implementation}: {et - st}"
        print(msg_str)
```
Output:
```
Time using solver SCS and _use_vectorized_implementation=False: 52.351640939712524
Time using solver SCS and _use_vectorized_implementation=True: 46.90113306045532
Time using solver ECOS and _use_vectorized_implementation=False: 6.936963081359863
Time using solver ECOS and _use_vectorized_implementation=True: 2.934386968612671
```