### PR TITLE
Allow for double-resection alleles in simulator

### DIFF
--- a/cassiopeia/simulator/Cas9LineageTracingDataSimulator.py
+++ b/cassiopeia/simulator/Cas9LineageTracingDataSimulator.py
@@ -104,7 +104,7 @@ class Cas9LineageTracingDataSimulator(LineageTracingDataSimulator):
         create_allele_when_collapsing_sites_on_cassette: Whether or not to
             create a new allele for the collapsed sites. If False, the default
             behavior of using heritable missing data is employed. Otherwise,
-            the new alleles are encoded as (1e8 + 2**starting_site +
+            the new allele is encoded as (1e8 + 2**starting_site +
             2**ending_site) where starting_site and ending_site are the first
             and last site involved in the resection. This allows inferring the
             endpoints of the resection event, as one would from real reads.

--- a/cassiopeia/simulator/Cas9LineageTracingDataSimulator.py
+++ b/cassiopeia/simulator/Cas9LineageTracingDataSimulator.py
@@ -317,10 +317,18 @@ class Cas9LineageTracingDataSimulator(LineageTracingDataSimulator):
                     np.min(sites_to_collapse),
                     np.max(sites_to_collapse),
                 )
+                casette_start_idx = (
+                    int(left / self.size_of_cassette)
+                    * self.size_of_cassette
+                )
                 state_to_use = (
                     self.heritable_missing_data_state
                     if not self.create_allele_when_collapsing_sites_on_cassette
-                    else self.number_of_states + 2**left + 2**right
+                    else (
+                        _MAX_NUMBER_OF_STATES
+                        + 2**(left - casette_start_idx)
+                        + 2**(right - casette_start_idx)
+                    )
                 )
                 for site in range(left, right + 1):
                     updated_character_array[

--- a/test/simulator_tests/cas9_lineage_tracing_simulator_test.py
+++ b/test/simulator_tests/cas9_lineage_tracing_simulator_test.py
@@ -69,7 +69,7 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
                 random_seed=123412232,
             )
         )
-        self.basic_lineage_tracing_data_simulator_w_alleles = (
+        self.basic_lineage_tracing_data_simulator_w_resection_alleles = (
             cas.sim.Cas9LineageTracingDataSimulator(
                 number_of_cassettes=3,
                 size_of_cassette=3,
@@ -337,7 +337,7 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
         (
             updated_character_array,
             remaining_cuts,
-        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+        ) = self.basic_lineage_tracing_data_simulator_w_resection_alleles.collapse_sites(
             character_array, [0, 1]
         )
         self.assertCountEqual([], remaining_cuts)
@@ -350,7 +350,7 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
         (
             updated_character_array,
             remaining_cuts,
-        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+        ) = self.basic_lineage_tracing_data_simulator_w_resection_alleles.collapse_sites(
             character_array, [0, 1, 2, 3, 4]
         )
         self.assertCountEqual([], remaining_cuts)
@@ -365,7 +365,7 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
         (
             updated_character_array,
             remaining_cuts,
-        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+        ) = self.basic_lineage_tracing_data_simulator_w_resection_alleles.collapse_sites(
             character_array, [0, 2, 3, 4, 7, 8]
         )
         self.assertCountEqual([], remaining_cuts)
@@ -381,7 +381,7 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
         (
             updated_character_array,
             remaining_cuts,
-        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+        ) = self.basic_lineage_tracing_data_simulator_w_resection_alleles.collapse_sites(
             character_array, [0, 5, 9]
         )
         self.assertCountEqual([0, 5, 9], remaining_cuts)

--- a/test/simulator_tests/cas9_lineage_tracing_simulator_test.py
+++ b/test/simulator_tests/cas9_lineage_tracing_simulator_test.py
@@ -69,6 +69,18 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
                 random_seed=123412232,
             )
         )
+        self.basic_lineage_tracing_data_simulator_w_alleles = (
+            cas.sim.Cas9LineageTracingDataSimulator(
+                number_of_cassettes=3,
+                size_of_cassette=3,
+                mutation_rate=0.3,
+                state_priors={1: 0.1, 2: 0.1, 3: 0.75, 4: 0.05},
+                heritable_silencing_rate=1e-5,
+                stochastic_silencing_rate=1e-2,
+                random_seed=123412232,
+                create_allele_when_collapsing_sites_on_cassette=True,
+            )
+        )
 
         self.basic_lineage_tracing_data_simulator_no_collapse = (
             cas.sim.Cas9LineageTracingDataSimulator(
@@ -310,6 +322,70 @@ class TestCas9LineageTracingDataSimulator(unittest.TestCase):
         )
         self.assertCountEqual([], remaining_cuts)
         expected_character_array = [-2, -2, 0, 0, 0, 0, 0, 0, 0]
+        for i in range(len(expected_character_array)):
+            self.assertEqual(
+                expected_character_array[i], updated_character_array[i]
+            )
+
+    def test_collapse_sites_with_alleles(self):
+        """
+        Same as `test_collapse_sites` but with resection alleles.
+        """
+
+        character_array = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+        (
+            updated_character_array,
+            remaining_cuts,
+        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+            character_array, [0, 1]
+        )
+        self.assertCountEqual([], remaining_cuts)
+        expected_character_array = [100000003, 100000003, 0, 0, 0, 0, 0, 0, 0]
+        for i in range(len(expected_character_array)):
+            self.assertEqual(
+                expected_character_array[i], updated_character_array[i]
+            )
+
+        (
+            updated_character_array,
+            remaining_cuts,
+        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+            character_array, [0, 1, 2, 3, 4]
+        )
+        self.assertCountEqual([], remaining_cuts)
+        expected_character_array = [
+            100000005, 100000005, 100000005, 100000003, 100000003, 0, 0, 0, 0
+        ]
+        for i in range(len(expected_character_array)):
+            self.assertEqual(
+                expected_character_array[i], updated_character_array[i]
+            )
+
+        (
+            updated_character_array,
+            remaining_cuts,
+        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+            character_array, [0, 2, 3, 4, 7, 8]
+        )
+        self.assertCountEqual([], remaining_cuts)
+        expected_character_array = [
+            100000005, 100000005, 100000005, 100000003, 100000003, 0, 0,
+            100000006, 100000006
+        ]
+        for i in range(len(expected_character_array)):
+            self.assertEqual(
+                expected_character_array[i], updated_character_array[i]
+            )
+
+        (
+            updated_character_array,
+            remaining_cuts,
+        ) = self.basic_lineage_tracing_data_simulator_w_alleles.collapse_sites(
+            character_array, [0, 5, 9]
+        )
+        self.assertCountEqual([0, 5, 9], remaining_cuts)
+        expected_character_array = [0, 0, 0, 0, 0, 0, 0, 0, 0]
         for i in range(len(expected_character_array)):
             self.assertEqual(
                 expected_character_array[i], updated_character_array[i]


### PR DESCRIPTION
Currently, the `Cas9LineageTracingDataSimulator` introduces missing data upon double resections, but these can be represented as alleles to make better use of the information. This PR extends the `Cas9LineageTracingDataSimulator` to create new alleles upon double resections. This code snippet exemplifies:

```
import networkx as nx

from cassiopeia.data import CassiopeiaTree
from cassiopeia.simulator import Cas9LineageTracingDataSimulator


tree = nx.DiGraph()
tree.add_node("0"), tree.add_node("1")
tree.add_edge("0", "1")
tree = CassiopeiaTree(tree=tree)

Cas9LineageTracingDataSimulator(
    mutation_rate=1000.0,
    number_of_cassettes=3,
    size_of_cassette=3,
).overlay_data(tree)
print(f"Character matrix before: {tree.character_matrix}")


Cas9LineageTracingDataSimulator(
    mutation_rate=1000.0,
    number_of_cassettes=3,
    size_of_cassette=3,
    create_allele_when_collapsing_sites_on_cassette=True,
).overlay_data(tree)
print(f"Character matrix after: {tree.character_matrix}")
```

With the new version, a double resection between sites i and j in a cassette creates a new allele at all intervening sites with integer value 1e8 + 2^i + 2^j. Because of this, it is not allowed to use the simulator with more than 1e8 states (an error will be raised otherwise). This is too large of a state space to be of interest so it is not a limitation.

I added a test in `cas9_lineage_tracing_simulator_test.py` to test the new collapsing functionality.