### PR TITLE
RF and triplets correct should deepcopy

### DIFF
--- a/cassiopeia/critique/compare.py
+++ b/cassiopeia/critique/compare.py
@@ -54,8 +54,8 @@ def triplets_correct(
     proportion_unresolvable = defaultdict(int)
 
     # create copies of the trees and collapse process
-    T1 = copy.copy(tree1)
-    T2 = copy.copy(tree2)
+    T1 = copy.deepcopy(tree1)
+    T2 = copy.deepcopy(tree2)
 
     T1.collapse_unifurcations()
     T2.collapse_unifurcations()
@@ -148,8 +148,8 @@ def robinson_foulds(
             Robinson-Foulds distance for downstream normalization
     """
     # create copies of the trees and collapse process
-    T1 = copy.copy(tree1)
-    T2 = copy.copy(tree2)
+    T1 = copy.deepcopy(tree1)
+    T2 = copy.deepcopy(tree2)
 
     # convert to Ete3 trees and collapse unifurcations
     T1.collapse_unifurcations()

--- a/cassiopeia/tools/fitness_estimator/_lbi_jungle.py
+++ b/cassiopeia/tools/fitness_estimator/_lbi_jungle.py
@@ -6,7 +6,6 @@ from typing import Optional
 import networkx as nx
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-print(f"dir_path = {dir_path}")
 sys.path.append(os.path.join(dir_path, "_jungle"))
 import jungle as jg
 import numpy as np


### PR DESCRIPTION
A CassiopeiaTree is a complex nested object and should always be deepcopied, not shallow copied. In robinson_founds and triplets_correct, shallow copies of the input trees are being created before collapsing unifurcations, which as a result modifies the input trees:

https://github.com/YosefLab/Cassiopeia/blame/master/cassiopeia/critique/compare.py#L56-L61

Example:

```
import networkx as nx
import cassiopeia

tree_nx = nx.DiGraph()
tree_nx.add_nodes_from(["0", "1", "2", "3"]),
tree_nx.add_edges_from(
    [
        ("0", "1"),
        ("1", "2"),
        ("1", "3"),
    ]
)
tree = cassiopeia.data.CassiopeiaTree(tree=tree_nx)
print(f"Tree before computing RF: {tree.get_newick()}")
cassiopeia.critique.compare.robinson_foulds(tree, tree)
print(f"Tree after computing RF: {tree.get_newick()}")
```

Output:

```
Tree before computing RF: ((2,3));
Tree after computing RF: (2,3);
```

Expected output:
```
Tree before computing RF: ((2,3));
Tree after computing RF: ((2,3));
```

Bug seems to have been introduced 2 years ago during a refactor of the critique module:

https://github.com/YosefLab/Cassiopeia/commit/27d165379ae5ac904891affb0e78fe6840e428c3
