### PR TITLE
Fixed ILP cython error caused by pandas update

### DIFF
--- a/cassiopeia/solver/ILPSolver.py
+++ b/cassiopeia/solver/ILPSolver.py
@@ -305,7 +305,7 @@ class ILPSolver(CassiopeiaSolver.CassiopeiaSolver):
 
         potential_graph_edges = (
             ilp_solver_utilities.infer_potential_graph_cython(
-                character_matrix.values.astype(str),
+                character_matrix.astype(str).values,
                 pid,
                 lca_height,
                 self.maximum_potential_graph_layer_size,


### PR DESCRIPTION
With pandas=2.0.2 the character matrix passed by `ILPSolver` to `ilp_solver_utilities.infer_potential_graph_cython` is not correctly formatted for cython. This patch fixes this bug.

=====================================================
ERROR: test_simple_potential_graph_inference (__main__.TestILPSolver)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/solver_tests/ilp_solver_test.py", line 119, in test_simple_potential_graph_inference
    potential_graph = self.ilp_solver.infer_potential_graph(
  File "/home/wcolgan/miniconda3/envs/tree-env/lib/python3.8/site-packages/cassiopeia/solver/ILPSolver.py", line 307, in infer_potential_graph
    ilp_solver_utilities.infer_potential_graph_cython(
  File "cassiopeia/solver/ilp_solver_utilities.pyx", line 21, in cassiopeia.solver.ilp_solver_utilities.infer_potential_graph_cython
    character_array: str[:, :],
ValueError: Does not understand character buffer dtype format string ('w')

----------------------------------------------------------------------