### PR TITLE
Fix chained assignment warning in utilities.py for pandas 3.0 compatibility

### DIFF
--- a/cassiopeia/preprocess/utilities.py
+++ b/cassiopeia/preprocess/utilities.py
@@ -522,7 +522,7 @@ def convert_alleletable_to_lineage_profile(
             val = tuple(val)
             if len(val) == 1:
                 val = val[0]
-            allele_piv.loc[j[0]][j[1], cutsite] = val
+            allele_piv.loc[j[0], (j[1], cutsite)] = val
 
     allele_piv2 = pd.pivot_table(
         allele_table,


### PR DESCRIPTION
This PR resolves a FutureWarning related to chained assignment in pandas. The original code used:
```
allele_piv.loc[j[0]][j[1], cutsite] = val
```

This triggers a warning under newer pandas versions due to potentially unsafe chained indexing. It was replaced with the recommended form:
```
allele_piv.loc[j[0], (j[1], cutsite)] = val
```

This ensures the assignment operates on the original DataFrame, maintaining compatibility with upcoming pandas 3.0 behavior (Copy-on-Write).

No functionality is changed — this is a forward-compatibility and code quality improvement.

The above mentioned FutureWarning:

```

[Cassiopeia/cassiopeia/preprocess/utilities.py:525](tzeitim/Cassiopeia/cassiopeia/preprocess/utilities.py#line=524): FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

  allele_piv.loc[j[0]][j[1], cutsite] = val

```