### PR TITLE
Bug fix: Use clustered lineage profile for indel color generation

### DIFF
--- a/cassiopeia/plotting/utilities.py
+++ b/cassiopeia/plotting/utilities.py
@@ -519,7 +519,7 @@ def prepare_alleletable(
     )
     clustered_linprof = lineage_profile.loc[leaves[::-1]]
     if indel_priors is None:
-        indel_colors = get_random_indel_colors(lineage_profile, random_state)
+        indel_colors = get_random_indel_colors(clustered_linprof, random_state)
     else:
         indel_colors = get_indel_colors(indel_priors, random_state)
     return clustered_linprof, indel_colors


### PR DESCRIPTION
Fixed inconsistency in `prepare_alleletable()` where indel colors were generated from the full lineage profile instead of the  filtered `clustered_linprof`. This ensures color generation is based on the same subset of data that gets returned for plotting. This resulted in an error when trying to retrieve data from an indel in the wrong scope.

For example in line cassiopeia/plotting/local.py:239:


```
--> 239     c = hsv_to_rgb(tuple(indel_colors.loc[ind, "color"]))

KeyError: 'CAGTC[46:2D]CGAAG'

```


The function in its original form creates clustered_linprof (line 520) which is a filtered version of the lineage profile containing only the specified leaves, the bug consists in the use the original lineage_profile to generate colors (line 522) instead of the filtered clustered_linprof.