### PR TITLE
Package ccphylo config default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include src/cassiopeia/preprocess/collapse_cython.c
 include src/cassiopeia/solver/ilp_solver_utilities.c
 include src/cassiopeia/**/*.pxd
+include src/cassiopeia/config.ini
 exclude src/cassiopeia/preprocess/collapse_cython.pyx
 exclude src/cassiopeia/solver/ilp_solver_utilities.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ exclude = [ "tests*", "docs*", "notebooks*", "data*" ]
 
 # If you ship .pxd, include them:
 [tool.setuptools.package-data]
-cassiopeia = [ "**/*.pxd" ]
+cassiopeia = [ "**/*.pxd", "config.ini" ]
 
 # --- Hatch envs ---
 

--- a/src/cassiopeia/config.ini
+++ b/src/cassiopeia/config.ini
@@ -1,0 +1,2 @@
+[Paths]
+ccphylo_path = /path/to/ccphylo/ccphylo


### PR DESCRIPTION
## Summary
- add the default ccphylo config.ini to the cassiopeia package data so it ships with builds
- include the config file in the manifest to ensure it is present in source distributions

## Testing
- pytest -q tests/solver_tests/ccphylo_solver_test.py -p no:warnings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692379258c38832096d1a8e140455a23)