### PR TITLE
Patch RF to handle root with single descendant

### DIFF
--- a/src/cassiopeia/critique/compare.py
+++ b/src/cassiopeia/critique/compare.py
@@ -168,7 +168,7 @@ def _run_triplets_correct(
 
 def _robinson_foulds_bitset(tree1: nx.DiGraph, tree2: nx.DiGraph):
     """Compute the unrooted Robinson–Foulds distance using bitsets."""
-    leaf_index = {leaf: i for i, leaf in enumerate(get_leaves(t1))}
+    leaf_index = {leaf: i for i, leaf in enumerate(get_leaves(tree1))}
 
     def get_splits(tree, leaf_index):
         """Return a set of canonical bitmasks representing bipartitions."""

--- a/src/cassiopeia/critique/compare.py
+++ b/src/cassiopeia/critique/compare.py
@@ -168,7 +168,7 @@ def _run_triplets_correct(
 
 def _robinson_foulds_bitset(tree1: nx.DiGraph, tree2: nx.DiGraph):
     """Compute the unrooted Robinson–Foulds distance using bitsets."""
-    leaf_index = {leaf: i for i, leaf in enumerate(get_leaves(t1)}
+    leaf_index = {leaf: i for i, leaf in enumerate(get_leaves(t1))}
 
     def get_splits(tree, leaf_index):
         """Return a set of canonical bitmasks representing bipartitions."""

--- a/src/cassiopeia/critique/compare.py
+++ b/src/cassiopeia/critique/compare.py
@@ -168,12 +168,7 @@ def _run_triplets_correct(
 
 def _robinson_foulds_bitset(tree1: nx.DiGraph, tree2: nx.DiGraph):
     """Compute the unrooted Robinson–Foulds distance using bitsets."""
-    leaves1 = sorted([n for n in tree1 if tree1.degree[n] == 1])
-    leaves2 = sorted([n for n in tree2 if tree2.degree[n] == 1])
-    if set(leaves1) != set(leaves2):
-        raise ValueError("Trees must have identical leaf sets.")
-
-    leaf_index = {leaf: i for i, leaf in enumerate(leaves1)}
+    leaf_index = {leaf: i for i, leaf in enumerate(get_leaves(t1)}
 
     def get_splits(tree, leaf_index):
         """Return a set of canonical bitmasks representing bipartitions."""


### PR DESCRIPTION
@isabellechan089 your `_robinson_foulds_bitset` implementation raises an error when the root has a single descendant because `leaves1 = sorted([n for n in tree1 if tree1.degree[n] == 1])` will incorrectly include it in the leaf set. I've patched it here but let's watch out for this failure mode in the future and be sure to include more tree topologies in the tests.