### PR TITLE
Fix pandas 3.0 / numpy 2 compatibility

### DIFF
--- a/src/cassiopeia/data/CassiopeiaTree.py
+++ b/src/cassiopeia/data/CassiopeiaTree.py
@@ -596,7 +596,7 @@ class CassiopeiaTree:
 
         # All nodes have a single character string, so we cast the character matrix
         # back to an integer.
-        self._character_matrix = self._character_matrix.astype(int, copy=False)
+        self._character_matrix = self._character_matrix.astype(int)
 
     def reconstruct_ancestral_characters(self) -> None:
         """Reconstruct ancestral character states.
@@ -985,9 +985,9 @@ class CassiopeiaTree:
             # character string.
             if self.is_ambiguous(node):
                 if layer is not None:
-                    self.layers[layer] = self.layers[layer].astype(object, copy=False)
+                    self.layers[layer] = self.layers[layer].astype(object)
                 else:
-                    self._character_matrix = self._character_matrix.astype(object, copy=False)
+                    self._character_matrix = self._character_matrix.astype(object)
 
             # Pass in as numpy array of tuples to bypass the VisibleDeprecationWarning
             # from creating an ndarray from ragged nested sequences

--- a/src/cassiopeia/data/utilities.py
+++ b/src/cassiopeia/data/utilities.py
@@ -394,7 +394,9 @@ def compute_phylogenetic_weight_matrix(
 
             W.loc[leaf1, leaf2] = W.loc[leaf2, leaf1] = _d
 
-    np.fill_diagonal(W.values, 0)
+    values = W.to_numpy(copy=True)
+    np.fill_diagonal(values, 0)
+    W = pd.DataFrame(values, index=W.index, columns=W.columns)
 
     return W
 

--- a/src/cassiopeia/preprocess/lineage_utils.py
+++ b/src/cassiopeia/preprocess/lineage_utils.py
@@ -100,12 +100,12 @@ def find_top_lg(
         pivot table of the remaining unassigned cells
     """
     # Calculate sum of observed intBCs, identify top intBC
-    intBC_sums = PIVOT_in.sum(0).sort_values(ascending=False)
+    intBC_sums = PIVOT_in.sum(axis=0).sort_values(ascending=False)
     intBC_top = intBC_sums.index[0]
 
     # Take subset of PIVOT table that contain cells that have the top intBC
     subPIVOT_in = PIVOT_in[PIVOT_in[intBC_top] > 0]
-    subPIVOT_in_sums = subPIVOT_in.sum(0)
+    subPIVOT_in_sums = subPIVOT_in.sum(axis=0)
     ordered_intBCs2 = subPIVOT_in_sums.sort_values(ascending=False).index.tolist()
     subPIVOT_in = subPIVOT_in[ordered_intBCs2]
 
@@ -113,7 +113,7 @@ def find_top_lg(
     subPIVOT_in[subPIVOT_in > 0] = 1
 
     # Define intBC set
-    subPIVOT_in_sums2 = subPIVOT_in.sum(0)
+    subPIVOT_in_sums2 = subPIVOT_in.sum(axis=0)
     total = subPIVOT_in_sums2[intBC_top]
     intBC_sums_filt = subPIVOT_in_sums2[subPIVOT_in_sums2 >= min_intbc_prop * total]
 
@@ -174,7 +174,7 @@ def filter_intbcs_lg_sets(
         PIVi_bin = PIVi_bin.drop(["lineageGrp"], axis=1)
         PIVi_bin[PIVi_bin > 0] = 1
 
-        intBC_sums = PIVi_bin.sum(0)
+        intBC_sums = PIVi_bin.sum(axis=0)
         intBC_normsums = intBC_sums / max(intBC_sums)
 
         intBC_normsums_filt_i = intBC_normsums[intBC_normsums >= min_intbc_thresh]

--- a/src/cassiopeia/preprocess/pipeline.py
+++ b/src/cassiopeia/preprocess/pipeline.py
@@ -1012,7 +1012,7 @@ def call_lineage_groups(
     # Reorder piv columns by binarized intBC frequency
     pivbin = piv.copy()
     pivbin[pivbin > 0] = 1
-    intBC_sums = pivbin.sum(0)
+    intBC_sums = pivbin.sum(axis=0)
     ordered_intBCs = intBC_sums.sort_values(ascending=False).index.tolist()
     piv = piv[ordered_intBCs]
     min_clust_size = int(min_cluster_prop * piv.shape[0])

--- a/src/cassiopeia/preprocess/utilities.py
+++ b/src/cassiopeia/preprocess/utilities.py
@@ -32,7 +32,7 @@ def log_molecule_table(wrapped: Callable):
     @functools.wraps(wrapped)
     def wrapper(*args, **kwargs):
         df = wrapped(*args, **kwargs)
-        umi_count = df["UMI"].dtype != object
+        umi_count = pd.api.types.is_numeric_dtype(df["UMI"])
         logger.debug(f"Resulting {'alleletable' if umi_count else 'molecule_table'} statistics:")
         logger.debug(f"# Reads: {df['readCount'].sum()}")
         logger.debug(f"# UMIs: {df['UMI'].sum() if umi_count else df.shape[0]}")
@@ -102,7 +102,7 @@ def filter_cells(
             A filtered molecule table
     """
     # Detect if the UMI column contains UMI counts or the actual UMI sequence
-    umi_count = molecule_table["UMI"].dtype != object
+    umi_count = pd.api.types.is_numeric_dtype(molecule_table["UMI"])
 
     cell_groups = molecule_table.groupby("cellBC")
     umis_per_cell = cell_groups["UMI"].sum() if umi_count else cell_groups.size()

--- a/tests/preprocess_tests/character_matrix_test.py
+++ b/tests/preprocess_tests/character_matrix_test.py
@@ -318,6 +318,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         pd.testing.assert_frame_equal(
             expected_lineage_profile,
             lineage_profile[expected_lineage_profile.columns],
+            check_dtype=False,
         )
 
     def test_alleletable_to_lineage_profile_with_conflicts(self):
@@ -377,6 +378,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         pd.testing.assert_frame_equal(
             expected_lineage_profile,
             lineage_profile[expected_lineage_profile.columns],
+            check_dtype=False,
         )
 
     def test_alleletable_to_lineage_profile_with_conflicts_no_collapse(self):
@@ -438,6 +440,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         pd.testing.assert_frame_equal(
             expected_lineage_profile,
             lineage_profile[expected_lineage_profile.columns],
+            check_dtype=False,
         )
 
     def test_lineage_profile_to_character_matrix_with_conflicts(self):
@@ -757,6 +760,7 @@ class TestCharacterMatrixFormation(unittest.TestCase):
         pd.testing.assert_frame_equal(
             expected_lineage_profile,
             lineage_profile[expected_lineage_profile.columns],
+            check_dtype=False,
         )
 
     def test_compute_empirical_indel_probabilities_multiple_variables_noncassiopeia_alleletable(


### PR DESCRIPTION
## Summary

The `cassiopeia` conda env now ships **pandas 3.0** and **numpy 2** (Python 3.12), which broke 15 tests. This PR restores compatibility; all changes remain backward compatible with the older pandas/numpy used on Python 3.10.

Result: **570 passed, 9 skipped** (was 15 failed), and Pandas4Warnings eliminated (74 → 2 warnings; the 2 remaining are the unrelated Python 3.12 `os.fork()` stdlib warning).

## Failures fixed

- **`preprocess/utilities.py`** — pandas 3.0 defaults string columns to `str`/pyarrow dtype instead of `object`, so `df["UMI"].dtype != object` misclassified UMI *sequences* as *counts* and then tried to `sum()`/`>=` strings against ints (`ArrowNotImplementedError`). Switched to `pd.api.types.is_numeric_dtype(...)`.
- **`data/utilities.py`** — pandas 3.0 Copy-on-Write makes `DataFrame.values` read-only, breaking `np.fill_diagonal(W.values, 0)` (`ValueError: underlying array is read-only`). Fill a copied array and rebuild the frame.
- **`tests/preprocess_tests/character_matrix_test.py`** — the manually-built expected lineage profiles are inferred as `StringDtype` by pandas 3.0 while the code returns `object`; values match, so compare with `check_dtype=False` (matching existing precedent at lines 910/941).

## Pandas4Warnings silenced (forward compatible with pandas 4.0)

- `.sum(0)` → `.sum(axis=0)` in `lineage_utils.py` and `pipeline.py` (reduction args become keyword-only in pandas 4.0).
- Dropped the deprecated `copy=False` kwarg from `.astype(...)` in `CassiopeiaTree.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)